### PR TITLE
Add option to read custom operators data from new `custom_operators` stream. Also add new method options for momentum equation and helper scripts for the new options.

### DIFF
--- a/src/core_atmosphere/Makefile
+++ b/src/core_atmosphere/Makefile
@@ -19,7 +19,8 @@ OBJS = mpas_atm_core.o \
        mpas_atm_core_interface.o \
        mpas_atm_dimensions.o \
        mpas_atm_threading.o \
-       mpas_atm_halos.o
+       mpas_atm_halos.o \
+       mpas_atm_custom_operators.o
 
 all: $(PHYSCORE) dycore diagcore atmcore utilities
 
@@ -61,9 +62,11 @@ atmcore: $(PHYSCORE) dycore diagcore $(OBJS)
 
 mpas_atm_core_interface.o: mpas_atm_core.o
 
-mpas_atm_core.o: dycore diagcore mpas_atm_threading.o mpas_atm_halos.o
+mpas_atm_core.o: dycore diagcore mpas_atm_threading.o mpas_atm_halos.o mpas_atm_custom_operators.o
 
 mpas_atm_dimensions.o:
+
+mpas_atm_custom_operators.o:
 
 clean:
 	( cd physics; $(MAKE) clean )

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -255,6 +255,16 @@
                      units="-"
                      description="Coefficient for the divergent component of the Laplacian filter of momentum in the relaxation zone"
                      possible_values="Positive real values"/>
+
+                <nml_option name="config_use_custom_weightsOnEdge" type="logical" default_value="false"
+                     units="-"
+                     description="Whether to use custom weightsOnEdge read from custom_operators stream file"
+                     possible_values="Logical values"/>
+
+                <nml_option name="config_use_custom_coeffs_reconstruct" type="logical" default_value="false"
+                     units="-"
+                     description="Whether to use custom coeffs_reconstruct read from custom_operators stream file"
+                     possible_values="Logical values"/>
         </nml_record>
 
         <nml_record name="damping" in_defaults="true">
@@ -3917,4 +3927,10 @@
 #ifdef DO_PHYSICS
 #include "physics/Registry_noahmp.xml"
 #endif
+
+<!-- **************************************************************************************** -->
+<!-- *********************************** Custom Operators *********************************** -->
+<!-- **************************************************************************************** -->
+
+#include "Registry_custom_operators.xml"
 </registry>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -265,6 +265,12 @@
                      units="-"
                      description="Whether to use custom coeffs_reconstruct read from custom_operators stream file"
                      possible_values="Logical values"/>
+
+                <nml_option name="config_ke_use_reconstructed_vel" type="logical" default_value="false"
+                     units="-"
+                     description="Whether to use the cell reconstructed velocity to compute the cell kinetic energy"
+                     possible_values="Logical values"/>
+
         </nml_record>
 
         <nml_record name="damping" in_defaults="true">

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -271,6 +271,11 @@
                      description="Whether to use the cell reconstructed velocity to compute the cell kinetic energy"
                      possible_values="Logical values"/>
 
+                <nml_option name="config_ke_use_vertex_reconstructed_vel" type="logical" default_value="false"
+                     units="-"
+                     description="Whether to use the vertex reconstructed velocity to compute the cell kinetic energy"
+                     possible_values="Logical values"/>
+
         </nml_record>
 
         <nml_record name="damping" in_defaults="true">

--- a/src/core_atmosphere/Registry_custom_operators.xml
+++ b/src/core_atmosphere/Registry_custom_operators.xml
@@ -11,6 +11,7 @@
     <package name="custom_operators" description="Read custom operators weights from NetCDF file"/>
     <package name="custom_weightsOnEdge" description="Read custom weightsOnEdge from custom operators stream NetCDF file"/>
     <package name="custom_coeffs_reconstruct" description="Read custom coefs_reconstruct from custom operators stream NetCDF file"/>
+    <package name="custom_vertex_coeffs_reconstruct" description="Read custom vertex_coefs_reconstruct from custom operators stream NetCDF file"/>
 </packages>
 
 <streams>
@@ -24,6 +25,7 @@
 
         <var name="coeffs_edge_tanVel_reconstruct" packages="custom_weightsOnEdge"/>
         <var name="coeffs_cell_vel_reconstruct" packages="custom_coeffs_reconstruct"/>
+        <var name="coeffs_vertex_vel_reconstruct" packages="custom_vertex_coeffs_reconstruct"/>
 
     </stream>
 
@@ -38,6 +40,10 @@
     <var name="coeffs_edge_tanVel_reconstruct" type="real" dimensions="trueMaxEdges2 nEdges" units="unitless"
         description="Custom weights used in reconstruction of tangential velocity for an edge"
         packages="custom_weightsOnEdge"/>
+
+    <var name="coeffs_vertex_vel_reconstruct" type="real" dimensions="R3 vertexDegree nVertices" units="unitless"
+        description="Coefficients to reconstruct velocity vectors at vertices"
+        packages="custom_vertex_coeffs_reconstruct"/>
 
 </var_struct>
 

--- a/src/core_atmosphere/Registry_custom_operators.xml
+++ b/src/core_atmosphere/Registry_custom_operators.xml
@@ -1,0 +1,37 @@
+<!-- <root> -->
+
+<packages>
+    <package name="custom_operators" description="Read custom operators weights from NetCDF file"/>
+    <package name="custom_weightsOnEdge" description="Read custom weightsOnEdge from custom operators stream NetCDF file"/>
+    <package name="custom_coeffs_reconstruct" description="Read custom coefs_reconstruct from custom operators stream NetCDF file"/>
+</packages>
+
+<streams>
+
+    <stream name="custom_operators"
+            type="input"
+            filename_template="custom_operators.nc"
+            input_interval="initial_only"
+            immutable="true"
+            packages="custom_operators">
+
+        <var name="coeffs_edge_tanVel_reconstruct" packages="custom_weightsOnEdge"/>
+        <var name="coeffs_cell_vel_reconstruct" packages="custom_coeffs_reconstruct"/>
+
+    </stream>
+
+</streams>
+
+<var_struct name="mesh" time_levs="1">
+
+    <var name="coeffs_cell_vel_reconstruct" type="real" dimensions="R3 maxEdges nCells" units="unitless"
+        description="Custom coefficients to reconstruct velocity vectors at cell centers"
+        packages="custom_coeffs_reconstruct"/>
+
+    <var name="coeffs_edge_tanVel_reconstruct" type="real" dimensions="maxEdges2 nEdges" units="unitless"
+        description="Custom weights used in reconstruction of tangential velocity for an edge"
+        packages="custom_weightsOnEdge"/>
+
+</var_struct>
+
+<!-- </root> -->

--- a/src/core_atmosphere/Registry_custom_operators.xml
+++ b/src/core_atmosphere/Registry_custom_operators.xml
@@ -1,5 +1,12 @@
 <!-- <root> -->
 
+<dims>
+
+    <dim name="trueMaxEdges2"
+         description="The true largest number of edges involved in reconstruction of tangential velocity for an edge"/>
+
+</dims>
+
 <packages>
     <package name="custom_operators" description="Read custom operators weights from NetCDF file"/>
     <package name="custom_weightsOnEdge" description="Read custom weightsOnEdge from custom operators stream NetCDF file"/>
@@ -28,7 +35,7 @@
         description="Custom coefficients to reconstruct velocity vectors at cell centers"
         packages="custom_coeffs_reconstruct"/>
 
-    <var name="coeffs_edge_tanVel_reconstruct" type="real" dimensions="maxEdges2 nEdges" units="unitless"
+    <var name="coeffs_edge_tanVel_reconstruct" type="real" dimensions="trueMaxEdges2 nEdges" units="unitless"
         description="Custom weights used in reconstruction of tangential velocity for an edge"
         packages="custom_weightsOnEdge"/>
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6487,7 +6487,7 @@ module atm_time_integration
 !DIR$ IVDEP
          !$acc loop vector
          do k=1,nVertLevels
-            h_edge(k,iEdge) = 0.5 * (h(k,cell1) + h(k,cell2))
+            h_edge(k,iEdge) = 0.5_RKIND * (h(k,cell1) + h(k,cell2))
          end do
 
       end do
@@ -6574,7 +6574,7 @@ module atm_time_integration
                !$acc loop vector
                do k=1,nVertLevels
 !                  ke(k,iCell) = ke(k,iCell) + 0.25 * dcEdge(iEdge) * dvEdge(iEdge) * u(k,iEdge)**2
-                  ke(k,iCell) = ke(k,iCell) + 0.25 * ke_edge(k,iEdge)
+                  ke(k,iCell) = ke(k,iCell) + 0.25_RKIND * ke_edge(k,iEdge)
                end do
             end do
 !DIR$ IVDEP
@@ -6593,7 +6593,7 @@ module atm_time_integration
 !DIR$ IVDEP
             !$acc loop vector
             do k=1,nVertLevels
-               ke(k,iCell) = 0.5 * (uReconstructZonal(k,iCell)**2 + uReconstructMeridional(k,iCell)**2)
+               ke(k,iCell) = 0.5_RKIND * (uReconstructZonal(k,iCell)**2 + uReconstructMeridional(k,iCell)**2)
             end do
          end do
          !$acc end parallel
@@ -6612,7 +6612,7 @@ module atm_time_integration
          !$acc parallel default(present)
          !$acc loop gang
          do iVertex=vertexStart,vertexEnd
-            r = 0.25 * invAreaTriangle(iVertex) 
+            r = 0.25_RKIND * invAreaTriangle(iVertex) 
             !$acc loop vector
             do k=1,nVertLevels
 
@@ -6739,7 +6739,7 @@ module atm_time_integration
       do iEdge = edgeStart,edgeEnd
 !DIR$ IVDEP
          do k=1,nVertLevels
-            pv_edge(k,iEdge) =  0.5 * (pv_vertex(k,verticesOnEdge(1,iEdge)) + pv_vertex(k,verticesOnEdge(2,iEdge)))
+            pv_edge(k,iEdge) =  0.5_RKIND * (pv_vertex(k,verticesOnEdge(1,iEdge)) + pv_vertex(k,verticesOnEdge(2,iEdge)))
          end do
       end do
       !$acc end parallel

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -120,6 +120,9 @@ module atm_time_integration
    ! if damping in the model changed with the simulation calendar
    real (kind=RKIND), parameter, private :: seconds_per_day = 86400.0_RKIND
 
+   ! Whether to use the reconstucted cell velocity to compute ke
+   logical :: config_ke_use_reconstructed_vel
+
 
    contains
 
@@ -764,6 +767,7 @@ module atm_time_integration
       type (mpas_pool_type), pointer :: state
       character (len=StrKIND), pointer :: config_time_integration
       logical, pointer :: config_apply_lbcs_ptr
+      logical, pointer :: config_ke_use_reconstructed_vel_ptr
 
 
       clock => domain % clock
@@ -773,6 +777,10 @@ module atm_time_integration
       call mpas_pool_get_config(block % configs, 'config_apply_lbcs', config_apply_lbcs_ptr)
 
       config_apply_lbcs = config_apply_lbcs_ptr
+
+      call mpas_pool_get_config(block % configs, 'config_ke_use_reconstructed_vel', config_ke_use_reconstructed_vel_ptr)
+
+      config_ke_use_reconstructed_vel = config_ke_use_reconstructed_vel_ptr
 
       if (trim(config_time_integration) == 'SRK3') then
          call atm_srk3(domain, dt, itimestep, exchange_halo_group)
@@ -1435,16 +1443,38 @@ module atm_time_integration
 
             call mpas_timer_start('atm_compute_solve_diagnostics')
 
-            allocate(ke_vertex(nVertLevels,nVertices+1))
-            allocate(ke_edge(nVertLevels,nEdges+1))
+            if (config_ke_use_reconstructed_vel) then
 
-            !$acc parallel default(present)
-            !$acc loop vector
-            do k = 1, nVertLevels
-               ke_vertex(k,nVertices+1) = 0.0_RKIND
-               ke_edge(k,nEdges+1) = 0.0_RKIND
-            end do
-            !$acc end parallel
+               call mpas_pool_get_array(state, 'u', u, 2)
+               call mpas_pool_get_array(diag, 'uReconstructX', uReconstructX)
+               call mpas_pool_get_array(diag, 'uReconstructY', uReconstructY)
+               call mpas_pool_get_array(diag, 'uReconstructZ', uReconstructZ)
+               call mpas_pool_get_array(diag, 'uReconstructZonal', uReconstructZonal)
+               call mpas_pool_get_array(diag, 'uReconstructMeridional', uReconstructMeridional)
+
+               call mpas_reconstruct(mesh, u,                &
+                                     uReconstructX,          &
+                                     uReconstructY,          &
+                                     uReconstructZ,          &
+                                     uReconstructZonal,      &
+                                     uReconstructMeridional, &
+                                     includeHalos=.true.     &
+                                    )
+
+            else
+
+               allocate(ke_vertex(nVertLevels,nVertices+1))
+               allocate(ke_edge(nVertLevels,nEdges+1))
+
+               !$acc parallel default(present)
+               !$acc loop vector
+               do k = 1, nVertLevels
+                  ke_vertex(k,nVertices+1) = 0.0_RKIND
+                  ke_edge(k,nEdges+1) = 0.0_RKIND
+               end do
+               !$acc end parallel
+
+           endif
    
 !$OMP PARALLEL DO
             do thread=1,nThreads
@@ -1455,8 +1485,10 @@ module atm_time_integration
             end do
 !$OMP END PARALLEL DO
 
-            deallocate(ke_vertex)
-            deallocate(ke_edge)
+            if (.not.config_ke_use_reconstructed_vel) then
+               deallocate(ke_vertex)
+               deallocate(ke_edge)
+            endif
 
             call mpas_timer_stop('atm_compute_solve_diagnostics')
 
@@ -6268,7 +6300,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(:), pointer :: dvEdge, dcEdge, invDvEdge, invDcEdge
       real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge, kiteAreasOnVertex, h_edge, h, u, v, &
                                                     vorticity, ke, pv_edge, pv_vertex, pv_cell, gradPVn, gradPVt, &
-                                                    divergence
+                                                    divergence, uReconstructZonal, uReconstructMeridional
       integer, dimension(:,:), pointer :: cellsOnEdge, cellsOnVertex, verticesOnEdge, edgesOnCell, edgesOnEdge, edgesOnVertex, &
                                           kiteForCell, verticesOnCell
       real (kind=RKIND), dimension(:,:), pointer :: edgesOnVertex_sign, edgesOnCell_sign
@@ -6292,6 +6324,11 @@ module atm_time_integration
       call mpas_pool_get_array(diag, 'pv_cell', pv_cell)
       call mpas_pool_get_array(diag, 'gradPVn', gradPVn)
       call mpas_pool_get_array(diag, 'gradPVt', gradPVt)
+
+      call mpas_pool_get_array(diag, 'uReconstructZonal', uReconstructZonal)
+      call mpas_pool_get_array(diag, 'uReconstructMeridional', uReconstructMeridional)
+
+
 
       call mpas_pool_get_array(mesh, 'weightsOnEdge', weightsOnEdge)
       call mpas_pool_get_array(mesh, 'kiteAreasOnVertex', kiteAreasOnVertex)
@@ -6326,6 +6363,7 @@ module atm_time_integration
                vertexDegree, dt, config_apvm_upwinding, &
                fVertex, fEdge, invAreaTriangle, invAreaCell, dvEdge, dcEdge, invDvEdge, invDcEdge, &
                weightsOnEdge, kiteAreasOnVertex, h_edge, h, u, v, vorticity, ke, pv_edge, pv_vertex, pv_cell, &
+               uReconstructZonal, uReconstructMeridional, &
                gradPVn, gradPVt, divergence, cellsOnEdge, cellsOnVertex, verticesOnEdge, edgesOnCell, edgesOnEdge, &
                edgesOnVertex, kiteForCell, verticesOnCell, edgesOnVertex_sign, edgesOnCell_sign, nEdgesOnCell, nEdgesOnEdge, &
                cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
@@ -6338,6 +6376,7 @@ module atm_time_integration
             vertexDegree, dt, config_apvm_upwinding, &
             fVertex, fEdge, invAreaTriangle, invAreaCell, dvEdge, dcEdge, invDvEdge, invDcEdge, &
             weightsOnEdge, kiteAreasOnVertex, h_edge, h, u, v, vorticity, ke, pv_edge, pv_vertex, pv_cell, &
+            uReconstructZonal, uReconstructMeridional, &
             gradPVn, gradPVt, divergence, cellsOnEdge, cellsOnVertex, verticesOnEdge, edgesOnCell, edgesOnEdge, &
             edgesOnVertex, kiteForCell, verticesOnCell, edgesOnVertex_sign, edgesOnCell_sign, nEdgesOnCell, nEdgesOnEdge, &
             cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
@@ -6371,6 +6410,7 @@ module atm_time_integration
       real (kind=RKIND), dimension(nVertLevels,nEdges+1) :: pv_edge
       real (kind=RKIND), dimension(nVertLevels,nVertices+1) :: pv_vertex
       real (kind=RKIND), dimension(nVertLevels,nCells+1) :: pv_cell
+      real (kind=RKIND), dimension(nVertLevels,nCells+1) :: uReconstructZonal, uReconstructMeridional
       real (kind=RKIND), dimension(nVertLevels,nEdges+1) :: gradPVn
       real (kind=RKIND), dimension(nVertLevels,nEdges+1) :: gradPVt
       real (kind=RKIND), dimension(nVertLevels,nCells+1) :: divergence
@@ -6415,7 +6455,27 @@ module atm_time_integration
       !$acc                   verticesOnEdge, &
       !$acc                   invDvEdge,invDcEdge)
       !$acc enter data copyin(u,h)
+      if (config_ke_use_reconstructed_vel) then
+         !$acc enter data copyin(uReconstructZonal,uReconstructMeridional)
+      endif
       MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
+
+      if (.not.config_ke_use_reconstructed_vel) then
+         !$acc parallel default(present)
+         !$acc loop gang
+         do iEdge=edgeStart,edgeEnd
+
+!  the first openmp barrier below is set so that ke_edge is computed
+!  it would be good to move this somewhere else?
+            efac = dcEdge(iEdge)*dvEdge(iEdge)
+
+            !$acc loop vector
+            do k=1,nVertLevels
+               ke_edge(k,iEdge) = efac*u(k,iEdge)**2
+            end do
+
+         enddo
+      endif
 
       !
       ! Compute height on cell edges at velocity locations
@@ -6432,15 +6492,6 @@ module atm_time_integration
          !$acc loop vector
          do k=1,nVertLevels
             h_edge(k,iEdge) = 0.5 * (h(k,cell1) + h(k,cell2))
-         end do
-
-!  the first openmp barrier below is set so that ke_edge is computed
-!  it would be good to move this somewhere else?
-
-         efac = dcEdge(iEdge)*dvEdge(iEdge)
-         !$acc loop vector
-         do k=1,nVertLevels
-            ke_edge(k,iEdge) = efac*u(k,iEdge)**2
          end do
 
       end do
@@ -6499,8 +6550,9 @@ module atm_time_integration
       end do
       !$acc end parallel
 
-
+      if (.not.config_ke_use_reconstructed_vel) then
 !$OMP BARRIER
+      endif
 
       !
       ! Compute kinetic energy in each cell (Ringler et al JCP 2009)
@@ -6510,32 +6562,50 @@ module atm_time_integration
       MPAS_ACC_TIMER_START('atm_compute_solve_diagnostics [ACC_data_xfer]')
       !$acc enter data create(ke)
       MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
-      !$acc parallel default(present)
-      !$acc loop gang
-      do iCell=cellStart,cellEnd
-         !$acc loop vector
-         do k=1,nVertLevels
-            ke(k,iCell) = 0.0_RKIND
-         end do
-         !$acc loop seq
-         do i=1,nEdgesOnCell(iCell)
-            iEdge = edgesOnCell(i,iCell)
+
+      if (.not.config_ke_use_reconstructed_vel) then
+
+         !$acc parallel default(present)
+         !$acc loop gang
+         do iCell=cellStart,cellEnd
             !$acc loop vector
             do k=1,nVertLevels
-!               ke(k,iCell) = ke(k,iCell) + 0.25 * dcEdge(iEdge) * dvEdge(iEdge) * u(k,iEdge)**2
-               ke(k,iCell) = ke(k,iCell) + 0.25 * ke_edge(k,iEdge)
+               ke(k,iCell) = 0.0_RKIND
+            end do
+            !$acc loop seq
+            do i=1,nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(i,iCell)
+               !$acc loop vector
+               do k=1,nVertLevels
+!                  ke(k,iCell) = ke(k,iCell) + 0.25 * dcEdge(iEdge) * dvEdge(iEdge) * u(k,iEdge)**2
+                  ke(k,iCell) = ke(k,iCell) + 0.25 * ke_edge(k,iEdge)
+               end do
+            end do
+!DIR$ IVDEP
+            !$acc loop vector
+            do k=1,nVertLevels
+               ke(k,iCell) = ke(k,iCell) * invAreaCell(iCell)
             end do
          end do
+         !$acc end parallel
+
+      else !config_ke_use_reconstructed_vel == .true.
+
+         !$acc parallel default(present)
+         !$acc loop gang
+         do iCell=cellStart,cellEnd
 !DIR$ IVDEP
-         !$acc loop vector
-         do k=1,nVertLevels
-            ke(k,iCell) = ke(k,iCell) * invAreaCell(iCell)
+            !$acc loop vector
+            do k=1,nVertLevels
+               ke(k,iCell) = 0.5 * (uReconstructZonal(k,iCell)**2 + uReconstructMeridional(k,iCell)**2)
+            end do
          end do
-      end do
-      !$acc end parallel
+         !$acc end parallel
+
+      endif
 
 
-      if (hollingsworth) then
+      if (hollingsworth .and. .not.config_ke_use_reconstructed_vel) then
 
          ! Compute ke at cell vertices - AG's new KE construction, part 1
          ! *** approximation here because we don't have inner triangle areas
@@ -6763,6 +6833,9 @@ module atm_time_integration
       !$acc                  verticesOnEdge, &
       !$acc                  fVertex,invDvEdge,invDcEdge)
       !$acc exit data delete(u,h)
+      if (config_ke_use_reconstructed_vel) then
+         !$acc exit data delete(uReconstructZonal,uReconstructMeridional)
+      endif
       !$acc exit data copyout(h_edge,vorticity,divergence, &
       !$acc                   ke, &
       !$acc                   v, &

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -778,10 +778,6 @@ module atm_time_integration
 
       config_apply_lbcs = config_apply_lbcs_ptr
 
-      call mpas_pool_get_config(block % configs, 'config_ke_use_reconstructed_vel', config_ke_use_reconstructed_vel_ptr)
-
-      config_ke_use_reconstructed_vel = config_ke_use_reconstructed_vel_ptr
-
       if (trim(config_time_integration) == 'SRK3') then
          call atm_srk3(domain, dt, itimestep, exchange_halo_group)
       else

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -184,13 +184,15 @@ module atm_time_integration
 
        ierr = 0
 
-       nullify(config_ke_use_reconstructed_vel_ptr)
-       call mpas_pool_get_config(blocklist % configs, 'config_ke_use_reconstructed_vel', config_ke_use_reconstructed_vel_ptr)
-
        nullify(config_ke_use_vertex_reconstructed_vel_ptr)
-       call mpas_pool_get_config(blocklist % configs, 'config_ke_use_vertex_reconstructed_vel', config_ke_use_reconstructed_vel_ptr)
+       call mpas_pool_get_config(blocklist % configs, 'config_ke_use_vertex_reconstructed_vel', config_ke_use_vertex_reconstructed_vel_ptr)
 
        if (config_ke_use_vertex_reconstructed_vel_ptr) then
+
+           nullify(config_ke_use_reconstructed_vel_ptr)
+           call mpas_pool_get_config(blocklist % configs, 'config_ke_use_reconstructed_vel', config_ke_use_reconstructed_vel_ptr)
+
+
            if (.not.config_ke_use_reconstructed_vel_ptr) then
                call mpas_log_write('The config_ke_use_vertex_reconstructed_vel=true option can only be', &
                                    messageType=MPAS_LOG_WARN)

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -121,7 +121,7 @@ module atm_time_integration
    real (kind=RKIND), parameter, private :: seconds_per_day = 86400.0_RKIND
 
    ! Whether to use the reconstucted cell velocity to compute ke
-   logical :: config_ke_use_reconstructed_vel
+   logical :: config_ke_use_reconstructed_vel, config_ke_use_vertex_reconstructed_vel
 
 
    contains
@@ -158,7 +158,7 @@ module atm_time_integration
        type (MPAS_streamManager_type), pointer :: streamManager
        integer, intent(out) :: ierr
 
-       logical, pointer :: config_positive_definite
+       logical, pointer :: config_positive_definite, config_ke_use_reconstructed_vel_ptr, config_ke_use_vertex_reconstructed_vel_ptr
 
 
        call mpas_log_write('')
@@ -182,10 +182,27 @@ module atm_time_integration
                                messageType=MPAS_LOG_WARN)
        end if
 
+       ierr = 0
+
+       nullify(config_ke_use_reconstructed_vel_ptr)
+       call mpas_pool_get_config(blocklist % configs, 'config_ke_use_reconstructed_vel', config_ke_use_reconstructed_vel_ptr)
+
+       nullify(config_ke_use_vertex_reconstructed_vel_ptr)
+       call mpas_pool_get_config(blocklist % configs, 'config_ke_use_vertex_reconstructed_vel', config_ke_use_reconstructed_vel_ptr)
+
+       if (config_ke_use_vertex_reconstructed_vel_ptr) then
+           if (.not.config_ke_use_reconstructed_vel_ptr) then
+               call mpas_log_write('The config_ke_use_vertex_reconstructed_vel=true option can only be', &
+                                   messageType=MPAS_LOG_WARN)
+               call mpas_log_write('used when config_ke_use_reconstructed_vel=true.', &
+                                   messageType=MPAS_LOG_WARN)
+           ierr = 1
+           endif
+       endif
+
        call mpas_log_write(' ----- done checking dynamics settings -----')
        call mpas_log_write('')
 
-       ierr = 0
 
    end subroutine mpas_atm_dynamics_checks
 
@@ -1456,6 +1473,18 @@ module atm_time_integration
                                      uReconstructMeridional, &
                                      includeHalos=.true.     &
                                     )
+               if (config_ke_use_vertex_reconstructed_vel) then
+
+                  allocate(ke_vertex(nVertLevels,nVertices+1))
+
+                  !$acc parallel default(present)
+                  !$acc loop vector
+                  do k = 1, nVertLevels
+                     ke_vertex(k,nVertices+1) = 0.0_RKIND
+                  end do
+                  !$acc end parallel
+
+               endif
 
             else
 
@@ -1484,6 +1513,10 @@ module atm_time_integration
             if (.not.config_ke_use_reconstructed_vel) then
                deallocate(ke_vertex)
                deallocate(ke_edge)
+            endif
+
+            if (config_ke_use_vertex_reconstructed_vel) then
+               deallocate(ke_vertex)
             endif
 
             call mpas_timer_stop('atm_compute_solve_diagnostics')
@@ -6303,6 +6336,7 @@ module atm_time_integration
       integer, dimension(:), pointer :: nEdgesOnCell, nEdgesOnEdge
 
       real (kind=RKIND), pointer :: config_apvm_upwinding
+      real (kind=RKIND), dimension(:,:,:), pointer :: vertex_coeffs_reconstruct
 
 
       call mpas_pool_get_config(configs, 'config_apvm_upwinding', config_apvm_upwinding)
@@ -6364,6 +6398,19 @@ module atm_time_integration
                edgesOnVertex, kiteForCell, verticesOnCell, edgesOnVertex_sign, edgesOnCell_sign, nEdgesOnCell, nEdgesOnEdge, &
                cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
                rk_step)
+
+      if (config_ke_use_vertex_reconstructed_vel) then
+
+          call mpas_pool_get_array(mesh, 'coeffs_vertex_vel_reconstruct', vertex_coeffs_reconstruct)
+
+          call atm_compute_solve_ke_use_vertex_reconstruct_work(nCells, nEdges, nVertices, &
+              vertexDegree, invAreaCell, &
+              kiteAreasOnVertex, kiteForCell, u, ke, &
+              edgesOnVertex, verticesOnCell, nEdgesOnCell, edgesOnCell, &
+              cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
+              vertex_coeffs_reconstruct)
+
+      endif
 
    end subroutine atm_compute_solve_diagnostics
 
@@ -6840,6 +6887,133 @@ module atm_time_integration
       MPAS_ACC_TIMER_STOP('atm_compute_solve_diagnostics [ACC_data_xfer]')
 
    end subroutine atm_compute_solve_diagnostics_work
+
+   subroutine atm_compute_solve_ke_use_vertex_reconstruct_work(nCells, nEdges, nVertices, &
+            vertexDegree, invAreaCell, &
+            kiteAreasOnVertex, kiteForCell, u, ke, &
+            edgesOnVertex, verticesOnCell, nEdgesOnCell, edgesOnCell, &
+            cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd, &
+            vertex_coeffs_reconstruct)
+
+      use mpas_atm_dimensions
+
+      implicit none
+
+      !
+      ! Dummy arguments
+      !
+      integer, intent(in) :: nCells, nEdges, nVertices, vertexDegree
+      real (kind=RKIND), dimension(nCells+1), intent(in) :: invAreaCell
+      real (kind=RKIND), dimension(3,nVertices+1), intent(in) :: kiteAreasOnVertex
+      real (kind=RKIND), dimension(nVertLevels,nEdges+1), intent(in) :: u
+      real (kind=RKIND), dimension(nVertLevels,nCells+1), intent(inout) :: ke
+      integer, dimension(3,nVertices+1), intent(in) :: edgesOnVertex
+      integer, dimension(maxEdges,nCells+1), intent(in) :: verticesOnCell
+      integer, dimension(nCells+1), intent(in) :: nEdgesOnCell
+      integer, dimension(maxEdges, nCells+1), intent(in) :: edgesOnCell
+      integer, dimension(maxEdges,nCells+1), intent(in) :: kiteForCell
+      real (kind=RKIND), dimension(3,vertexDegree,nVertices+1), intent(in) :: vertex_coeffs_reconstruct
+
+      integer, intent(in) :: cellStart, cellEnd, vertexStart, vertexEnd, edgeStart, edgeEnd
+
+      !
+      ! Local variables
+      !
+      integer :: iCell, iVertex, k, i, j
+      real (kind=RKIND) :: u1, u2, u3, ux_vert, uy_vert, uz_vert
+      real (kind=RKIND) :: fac_x1, fac_x2, fac_x3, &
+                           fac_y1, fac_y2, fac_y3, &
+                           fac_z1, fac_z2, fac_z3
+      integer :: e1, e2, e3
+
+      real (kind=RKIND) :: ke_fact, efac, r
+
+      MPAS_ACC_TIMER_START('atm_compute_solve_ke_use_vertex_vel_reconsturct [ACC_data_xfer]')
+      !$acc enter data copyin(edgesOnVertex, &
+      !$acc                   nEdgesOnCell,edgesOnCell, &
+      !$acc                   invAreaCell, &
+      !$acc                   edgesOnVertex, &
+      !$acc                   verticesOnCell,kiteForCell,kiteAreasOnVertex, &
+      !$acc                   vertex_coeffs_reconstruct)
+      !$acc enter data copyin(u,ke)
+      MPAS_ACC_TIMER_STOP('atm_compute_solve_ke_use_vertex_vel_reconstruct [ACC_data_xfer]')
+
+
+      !$acc loop gang
+      do iVertex=vertexStart,vertexEnd
+
+         e1 = edgesOnVertex(1, iVertex)
+         e2 = edgesOnVertex(2, iVertex)
+         e3 = edgesOnVertex(3, iVertex)
+
+         fac_x1 = vertex_coeffs_reconstruct(1,1,iVertex)
+         fac_y1 = vertex_coeffs_reconstruct(2,1,iVertex)
+         fac_z1 = vertex_coeffs_reconstruct(3,1,iVertex)
+
+         fac_x2 = vertex_coeffs_reconstruct(1,2,iVertex)
+         fac_y2 = vertex_coeffs_reconstruct(2,2,iVertex)
+         fac_z2 = vertex_coeffs_reconstruct(3,2,iVertex)
+
+         fac_x3 = vertex_coeffs_reconstruct(1,3,iVertex)
+         fac_y3 = vertex_coeffs_reconstruct(2,3,iVertex)
+         fac_z3 = vertex_coeffs_reconstruct(3,3,iVertex)
+
+!DIR$ IVDEP
+         !$acc loop vector
+         do k=1,nVertLevels
+            u1 = u(k,e1)
+            u2 = u(k,e2)
+            u3 = u(k,e3)
+
+            ux_vert = fac_x1*u1 + fac_x2*u2 + fac_x3*u3
+            uy_vert = fac_y1*u1 + fac_y2*u2 + fac_y3*u3
+            uz_vert = fac_z1*u1 + fac_z2*u2 + fac_z3*u3
+
+            ke_vertex(k,iVertex) = 0.5_RKIND*(ux_vert*ux_vert + uy_vert*uy_vert + uz_vert*uz_vert)
+
+         end do
+      end do
+
+!$OMP BARRIER
+
+      ke_fact = 1.0 - .375
+
+      !$acc loop gang
+      do iCell=cellStart,cellEnd
+!DIR$ IVDEP
+         !$acc loop vector
+         do k=1,nVertLevels
+            ke(k,iCell) = ke_fact * ke(k,iCell)
+         end do
+      end do
+
+      !$acc loop gang
+      do iCell=cellStart,cellEnd
+         r = invAreaCell(iCell)
+         !$acc loop seq
+         do i=1,nEdgesOnCell(iCell)
+            iVertex = verticesOnCell(i,iCell)
+            j = kiteForCell(i,iCell)
+!DIR$ IVDEP
+            !$acc loop vector
+            do k = 1,nVertLevels
+               ke(k,iCell) = ke(k,iCell) + (1.-ke_fact)*kiteAreasOnVertex(j,iVertex) * ke_vertex(k,iVertex) * r
+            end do
+         end do
+      end do
+
+      MPAS_ACC_TIMER_START('atm_compute_solve_ke_use_vertex_reconstruct [ACC_data_xfer]')
+      !$acc exit data delete(edgesOnVertex, &
+      !$acc                  nEdgesOnCell,edgesOnCell, &
+      !$acc                  invAreaCell, &
+      !$acc                  edgesOnVertex, &
+      !$acc                  verticesOnCell,kiteForCell,kiteAreasOnVertex, &
+      !$acc                  vertex_coeffs_reconstruct)
+      !$acc exit data delete(u)
+      !$acc exit data copyout(ke)
+      MPAS_ACC_TIMER_STOP('atm_compute_solve_ke_use_vertex_reconstruct [ACC_data_xfer]')
+
+   end subroutine atm_compute_solve_ke_use_vertex_reconstruct_work
 
 
    subroutine atm_init_coupled_diagnostics(state, time_lev, diag, mesh, configs, &

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -260,6 +260,17 @@ module atm_core
       end if
 
 
+      ! Note: The 'custom_operators' stream has the 'custom_operators' package attached to it, the MPAS_stream_mgr_read( )
+      !       call here will actually try to read the stream only if custom_operators is being used in the run.
+      call MPAS_stream_mgr_read(domain % streamManager, streamID='custom_operators', whence=MPAS_STREAM_NEAREST, ierr=ierr)
+      if (ierr /= MPAS_STREAM_MGR_NOERR) then
+         call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_ERR)
+         call mpas_log_write('Error reading custom_operators stream',                                                          messageType=MPAS_LOG_ERR)
+         call mpas_log_write('********************************************************************************', messageType=MPAS_LOG_CRIT)
+      end if
+      call MPAS_stream_mgr_reset_alarms(domain % streamManager, streamID='custom_operators', ierr=ierr)
+
+
       block => domain % blocklist
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'mesh', mesh)

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -372,6 +372,7 @@ module atm_core
       use mpas_vector_reconstruction
       use mpas_stream_manager
       use mpas_atm_boundaries, only : mpas_atm_setup_bdy_masks
+      use mpas_atm_custom_operators, only: mpas_atm_init_custom_operators
 #ifdef DO_PHYSICS
 !     use mpas_atmphys_aquaplanet
       use mpas_atmphys_control
@@ -533,6 +534,8 @@ module atm_core
 
       call mpas_rbf_interp_initialize(mesh)
       call mpas_init_reconstruct(mesh)
+
+      call mpas_atm_init_custom_operators(block, mesh)
 
       call mpas_pool_get_array(state, 'u', u, 1)
       call mpas_pool_get_array(diag, 'uReconstructX', uReconstructX)

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -495,7 +495,7 @@ module atm_core
       nVertices = nVertices_ptr
       nVertLevels = nVertLevels_ptr
 
-      if (.not.config_ke_use_reconstructed_vel_local) then
+      if (.not.config_ke_use_reconstructed_vel) then
          allocate(ke_vertex(nVertLevels,nVertices+1))  ! ke_vertex is a module variable defined in mpas_atm_time_integration.F
          allocate(ke_edge(nVertLevels,nEdges+1))       ! ke_edge is a module variable defined in mpas_atm_time_integration.F
          !$acc parallel default(present)

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -431,7 +431,8 @@ module atm_core
       integer, dimension(:), pointer :: vertexSolveThreadStart, vertexSolveThreadEnd
 
 
-      logical, pointer :: config_do_restart, config_do_DAcycling, config_ke_use_reconstructed_vel_ptr
+      logical, pointer :: config_do_restart, config_do_DAcycling
+      logical, pointer :: config_ke_use_reconstructed_vel_ptr, config_ke_use_vertex_reconstructed_vel_ptr
 
       call atm_compute_signs(mesh)
    
@@ -443,8 +444,10 @@ module atm_core
       call mpas_pool_get_config(block % configs, 'config_do_restart', config_do_restart)
       call mpas_pool_get_config(block % configs, 'config_do_DAcycling', config_do_DAcycling)
       call mpas_pool_get_config(block % configs, 'config_ke_use_reconstructed_vel', config_ke_use_reconstructed_vel_ptr)
+      call mpas_pool_get_config(block % configs, 'config_ke_use_vertex_reconstructed_vel', config_ke_use_vertex_reconstructed_vel_ptr)
 
       config_ke_use_reconstructed_vel = config_ke_use_reconstructed_vel_ptr
+      config_ke_use_vertex_reconstructed_vel = config_ke_use_vertex_reconstructed_vel_ptr
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       !!!! Compute inverses to avoid divides later
@@ -509,6 +512,16 @@ module atm_core
          !$acc end parallel
       endif
 
+      if (config_ke_use_vertex_reconstructed_vel) then
+         allocate(ke_vertex(nVertLevels,nVertices+1))  ! ke_vertex is a module variable defined in mpas_atm_time_integration.F
+         !$acc parallel default(present)
+         !$acc loop vector
+         do k = 1, nVertLevels
+            ke_vertex(k,nVertices+1) = 0.0_RKIND
+         end do
+         !$acc end parallel
+      endif
+
       call mpas_rbf_interp_initialize(mesh)
       call mpas_init_reconstruct(mesh)
 
@@ -568,6 +581,10 @@ module atm_core
       if (.not.config_ke_use_reconstructed_vel) then
          deallocate(ke_vertex)
          deallocate(ke_edge)
+      endif
+
+      if (config_ke_use_vertex_reconstructed_vel) then
+         deallocate(ke_vertex)
       endif
    
 #ifdef DO_PHYSICS

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -442,6 +442,7 @@ module atm_core
 
       call mpas_pool_get_config(block % configs, 'config_do_restart', config_do_restart)
       call mpas_pool_get_config(block % configs, 'config_do_DAcycling', config_do_DAcycling)
+      call mpas_pool_get_config(block % configs, 'config_ke_use_reconstructed_vel', config_ke_use_reconstructed_vel)
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       !!!! Compute inverses to avoid divides later
@@ -494,15 +495,37 @@ module atm_core
       nVertices = nVertices_ptr
       nVertLevels = nVertLevels_ptr
 
-      allocate(ke_vertex(nVertLevels,nVertices+1))  ! ke_vertex is a module variable defined in mpas_atm_time_integration.F
-      allocate(ke_edge(nVertLevels,nEdges+1))       ! ke_edge is a module variable defined in mpas_atm_time_integration.F
-      !$acc parallel default(present)
-      !$acc loop vector
-      do k = 1, nVertLevels
-         ke_vertex(k,nVertices+1) = 0.0_RKIND
-         ke_edge(k,nEdges+1) = 0.0_RKIND
-      end do
-      !$acc end parallel
+      if (.not.config_ke_use_reconstructed_vel_local) then
+         allocate(ke_vertex(nVertLevels,nVertices+1))  ! ke_vertex is a module variable defined in mpas_atm_time_integration.F
+         allocate(ke_edge(nVertLevels,nEdges+1))       ! ke_edge is a module variable defined in mpas_atm_time_integration.F
+         !$acc parallel default(present)
+         !$acc loop vector
+         do k = 1, nVertLevels
+            ke_vertex(k,nVertices+1) = 0.0_RKIND
+            ke_edge(k,nEdges+1) = 0.0_RKIND
+         end do
+         !$acc end parallel
+      endif
+
+      call mpas_rbf_interp_initialize(mesh)
+      call mpas_init_reconstruct(mesh)
+
+      call mpas_atm_init_custom_operators(block, mesh)
+
+      call mpas_pool_get_array(state, 'u', u, 1)
+      call mpas_pool_get_array(diag, 'uReconstructX', uReconstructX)
+      call mpas_pool_get_array(diag, 'uReconstructY', uReconstructY)
+      call mpas_pool_get_array(diag, 'uReconstructZ', uReconstructZ)
+      call mpas_pool_get_array(diag, 'uReconstructZonal', uReconstructZonal)
+      call mpas_pool_get_array(diag, 'uReconstructMeridional', uReconstructMeridional)
+      call mpas_reconstruct(mesh, u,                                           &
+                            uReconstructX,                                     &
+                            uReconstructY,                                     &
+                            uReconstructZ,                                     &
+                            uReconstructZonal,                                 &
+                            uReconstructMeridional,                            &
+                            includeHalos=config_ke_use_reconstructed_vel &
+                           )
 
       call mpas_pool_get_dimension(block % dimensions, 'nThreads', nThreads)
 
@@ -540,27 +563,10 @@ module atm_core
       end do
 !$OMP END PARALLEL DO
 
-      deallocate(ke_vertex)
-      deallocate(ke_edge)
-
-      call mpas_rbf_interp_initialize(mesh)
-      call mpas_init_reconstruct(mesh)
-
-      call mpas_atm_init_custom_operators(block, mesh)
-
-      call mpas_pool_get_array(state, 'u', u, 1)
-      call mpas_pool_get_array(diag, 'uReconstructX', uReconstructX)
-      call mpas_pool_get_array(diag, 'uReconstructY', uReconstructY)
-      call mpas_pool_get_array(diag, 'uReconstructZ', uReconstructZ)
-      call mpas_pool_get_array(diag, 'uReconstructZonal', uReconstructZonal)
-      call mpas_pool_get_array(diag, 'uReconstructMeridional', uReconstructMeridional)
-      call mpas_reconstruct(mesh, u,                   &
-                            uReconstructX,             &
-                            uReconstructY,             &
-                            uReconstructZ,             &
-                            uReconstructZonal,         &
-                            uReconstructMeridional     &
-                           )
+      if (.not.config_ke_use_reconstructed_vel) then
+         deallocate(ke_vertex)
+         deallocate(ke_edge)
+      endif
    
 #ifdef DO_PHYSICS
       !proceed with initialization of physics parameterization if moist_physics is set to true:

--- a/src/core_atmosphere/mpas_atm_core.F
+++ b/src/core_atmosphere/mpas_atm_core.F
@@ -431,7 +431,7 @@ module atm_core
       integer, dimension(:), pointer :: vertexSolveThreadStart, vertexSolveThreadEnd
 
 
-      logical, pointer :: config_do_restart, config_do_DAcycling
+      logical, pointer :: config_do_restart, config_do_DAcycling, config_ke_use_reconstructed_vel_ptr
 
       call atm_compute_signs(mesh)
    
@@ -442,7 +442,9 @@ module atm_core
 
       call mpas_pool_get_config(block % configs, 'config_do_restart', config_do_restart)
       call mpas_pool_get_config(block % configs, 'config_do_DAcycling', config_do_DAcycling)
-      call mpas_pool_get_config(block % configs, 'config_ke_use_reconstructed_vel', config_ke_use_reconstructed_vel)
+      call mpas_pool_get_config(block % configs, 'config_ke_use_reconstructed_vel', config_ke_use_reconstructed_vel_ptr)
+
+      config_ke_use_reconstructed_vel = config_ke_use_reconstructed_vel_ptr
 
       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       !!!! Compute inverses to avoid divides later

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -130,6 +130,8 @@ module atm_core_interface
       character(len=StrKIND), pointer :: config_gwdo_scheme
       logical, pointer :: config_ngw_scheme
       logical, pointer :: config_ugwp_diags
+      logical, pointer :: config_use_custom_weightsOnEdge, config_use_custom_coeffs_reconstruct
+      logical, pointer :: custom_operatorsActive, custom_weightsOnEdgeActive, custom_coeffs_reconstructActive
       character(len=StrKIND) :: attvalue
       integer :: local_ierr
 
@@ -258,6 +260,44 @@ module atm_core_interface
       end if
 
 #endif
+
+      ! Optional custom weightsOnEdge to be read from custom_operators stream
+      nullify(config_use_custom_weightsOnEdge)
+      call mpas_pool_get_config(configs, 'config_use_custom_weightsOnEdge', config_use_custom_weightsOnEdge)
+      nullify(custom_weightsOnEdgeActive)
+      call mpas_pool_get_package(packages, 'custom_weightsOnEdgeActive', custom_weightsOnEdgeActive)
+      if ( associated(config_use_custom_weightsOnEdge) .and. associated(custom_weightsOnEdgeActive) ) then
+          custom_weightsOnEdgeActive = config_use_custom_weightsOnEdge
+      else
+         ierr = ierr + 1
+         call mpas_log_write("Package setup failed for 'custom_weightsOnEdge'. 'custom_weightsOnEdge' is not a package.", &
+                             messageType=MPAS_LOG_ERR)
+      end if
+
+      ! Optional custom coeffs_reconstruct to be read from custom_operators stream
+      nullify(config_use_custom_coeffs_reconstruct)
+      call mpas_pool_get_config(configs, 'config_use_custom_coeffs_reconstruct', config_use_custom_coeffs_reconstruct)
+      nullify(custom_coeffs_reconstructActive)
+      call mpas_pool_get_package(packages, 'custom_coeffs_reconstructActive', custom_coeffs_reconstructActive)
+      if ( associated(config_use_custom_coeffs_reconstruct) .and. associated(custom_coeffs_reconstructActive) ) then
+          custom_coeffs_reconstructActive = config_use_custom_coeffs_reconstruct
+      else
+         ierr = ierr + 1
+         call mpas_log_write("Package setup failed for 'custom_coeffs_reconstruct'. 'custom_coeffs_reconstruct' is not a package.", &
+                             messageType=MPAS_LOG_ERR)
+      end if
+
+      ! If either config_use_custom_coeffs_reconstruct or config_use_custom_weightsOnEdge is true
+      ! we need the custom_operators stream.
+      nullify(custom_operatorsActive)
+      call mpas_pool_get_package(packages, 'custom_operatorsActive', custom_operatorsActive)
+      if ( associated(custom_operatorsActive) ) then
+          custom_operatorsActive = (custom_weightsOnEdgeActive .or. custom_coeffs_reconstructActive)
+      else
+         ierr = ierr + 1
+         call mpas_log_write("Package setup failed for 'custom_operators'. 'custom_operators' is not a package.", &
+                             messageType=MPAS_LOG_ERR)
+      end if
 
    end function atm_setup_packages
 

--- a/src/core_atmosphere/mpas_atm_core_interface.F
+++ b/src/core_atmosphere/mpas_atm_core_interface.F
@@ -132,6 +132,7 @@ module atm_core_interface
       logical, pointer :: config_ugwp_diags
       logical, pointer :: config_use_custom_weightsOnEdge, config_use_custom_coeffs_reconstruct
       logical, pointer :: custom_operatorsActive, custom_weightsOnEdgeActive, custom_coeffs_reconstructActive
+      logical, pointer :: config_ke_use_vertex_reconstructed_vel, custom_vertex_coeffs_reconstructActive
       character(len=StrKIND) :: attvalue
       integer :: local_ierr
 
@@ -287,12 +288,27 @@ module atm_core_interface
                              messageType=MPAS_LOG_ERR)
       end if
 
-      ! If either config_use_custom_coeffs_reconstruct or config_use_custom_weightsOnEdge is true
+      ! Optional coeffs_vertex_vel_reconstruct to be read from custom_operators stream
+      nullify(config_ke_use_vertex_reconstructed_vel)
+      call mpas_pool_get_config(configs, 'config_ke_use_vertex_reconstructed_vel', config_ke_use_vertex_reconstructed_vel)
+      nullify(custom_vertex_coeffs_reconstructActive)
+      call mpas_pool_get_package(packages, 'custom_vertex_coeffs_reconstructActive', custom_vertex_coeffs_reconstructActive)
+      if ( associated(config_ke_use_vertex_reconstructed_vel) .and. associated(custom_vertex_coeffs_reconstructActive) ) then
+          custom_vertex_coeffs_reconstructActive = config_ke_use_vertex_reconstructed_vel
+      else
+         ierr = ierr + 1
+         call mpas_log_write("Package setup failed for 'custom_vertex_coeffs_reconstruct'. 'custom_vertex_coeffs_reconstruct' is not a package.", &
+                             messageType=MPAS_LOG_ERR)
+      end if
+
+
+      ! If either config_use_custom_coeffs_reconstruct or config_use_custom_weightsOnEdge
+      ! or config_ke_use_vertex_reconstructed_vel is true
       ! we need the custom_operators stream.
       nullify(custom_operatorsActive)
       call mpas_pool_get_package(packages, 'custom_operatorsActive', custom_operatorsActive)
       if ( associated(custom_operatorsActive) ) then
-          custom_operatorsActive = (custom_weightsOnEdgeActive .or. custom_coeffs_reconstructActive)
+          custom_operatorsActive = (custom_weightsOnEdgeActive .or. custom_coeffs_reconstructActive .or. custom_vertex_coeffs_reconstructActive)
       else
          ierr = ierr + 1
          call mpas_log_write("Package setup failed for 'custom_operators'. 'custom_operators' is not a package.", &

--- a/src/core_atmosphere/mpas_atm_custom_operators.F
+++ b/src/core_atmosphere/mpas_atm_custom_operators.F
@@ -18,14 +18,20 @@ module mpas_atm_custom_operators
       logical, pointer :: config_use_custom_weightsOnEdge
       logical, pointer :: config_use_custom_coeffs_reconstruct
 
+      integer, pointer :: trueMaxEdges2_ptr
+      integer :: trueMaxEdges2
+
       call mpas_pool_get_config(block % configs, 'config_use_custom_weightsOnEdge', config_use_custom_weightsOnEdge)
 
       if (config_use_custom_weightsOnEdge) then
 
          call mpas_pool_get_array(mesh, 'weightsOnEdge', weightsOnEdge)
          call mpas_pool_get_array(mesh, 'coeffs_edge_tanVel_reconstruct', new_weightsOnEdge)
+         call mpas_pool_get_dimension(mesh, 'trueMaxEdges2', trueMaxEdges2_ptr)
 
-         weightsOnEdge(:,:) = new_weightsOnEdge(:,:)
+         trueMaxEdges2 = trueMaxEdges2_ptr
+
+         weightsOnEdge(1:trueMaxEdges2,:) = new_weightsOnEdge(1:trueMaxEdges2,:)
 
       end if
 

--- a/src/core_atmosphere/mpas_atm_custom_operators.F
+++ b/src/core_atmosphere/mpas_atm_custom_operators.F
@@ -1,0 +1,45 @@
+module mpas_atm_custom_operators
+
+   use mpas_derived_types
+   use mpas_pool_routines
+
+   contains
+
+   subroutine mpas_atm_init_custom_operators(block, mesh)
+
+      implicit none
+
+      type (block_type), intent(inout) :: block
+      type (mpas_pool_type), intent(inout) :: mesh
+
+      real (kind=RKIND), dimension(:,:), pointer :: weightsOnEdge, new_weightsOnEdge
+      real (kind=RKIND), dimension(:,:,:), pointer :: coeffs_reconstruct, new_coeffs_reconstruct
+
+      logical, pointer :: config_use_custom_weightsOnEdge
+      logical, pointer :: config_use_custom_coeffs_reconstruct
+
+      call mpas_pool_get_config(block % configs, 'config_use_custom_weightsOnEdge', config_use_custom_weightsOnEdge)
+
+      if (config_use_custom_weightsOnEdge) then
+
+         call mpas_pool_get_array(mesh, 'weightsOnEdge', weightsOnEdge)
+         call mpas_pool_get_array(mesh, 'coeffs_edge_tanVel_reconstruct', new_weightsOnEdge)
+
+         weightsOnEdge(:,:) = new_weightsOnEdge(:,:)
+
+      end if
+
+      call mpas_pool_get_config(block % configs, 'config_use_custom_coeffs_reconstruct', config_use_custom_coeffs_reconstruct)
+
+      if (config_use_custom_coeffs_reconstruct) then
+
+         call mpas_pool_get_array(mesh, 'coeffs_reconstruct', coeffs_reconstruct)
+         call mpas_pool_get_array(mesh, 'coeffs_cell_vel_reconstruct', new_coeffs_reconstruct)
+
+         coeffs_reconstruct(:,:,:) = new_coeffs_reconstruct(:,:,:)
+
+      end if
+
+   end subroutine mpas_atm_init_custom_operators
+
+end module mpas_atm_custom_operators

--- a/usp-utils/README.md
+++ b/usp-utils/README.md
@@ -13,6 +13,8 @@ If the user has installed the conda environment provided by `install_conda_envir
 
 Pre and post processing scripts are placed in `./pre_proc` and `./post_proc` respectively.
 
+Julia scipts (`.jl` files) rely on a shared environment called `cgfd-usp-mpas` which can be installed with the `install_julia_environment.jl` script. The same script can also be used to update the environment.
+
 ### Note to developers
 
 New python **modules** (scripts containing definitions that are imported into other scripts) should be placed into `./libs/py`, not in the same folder as the actual scripts importing it.

--- a/usp-utils/install_julia_environment.jl
+++ b/usp-utils/install_julia_environment.jl
@@ -1,0 +1,22 @@
+#!/usr/bin/env julia
+
+import Pkg
+import Pkg: PackageSpec
+
+#Packages to install
+const pkgs = [
+              PackageSpec("NCDatasets"),
+              PackageSpec("DelaunayTriangulation"),
+              PackageSpec("GLMakie"),
+              PackageSpec("Comonicon"),
+              PackageSpec(url="https://github.com/favba/TensorsLite.jl.git"),
+              PackageSpec(url="https://github.com/favba/TensorsLiteGeometry.jl.git"),
+              PackageSpec(url="https://github.com/favba/VoronoiMeshes.jl.git"),
+              PackageSpec(url="https://github.com/favba/VoronoiOperators.jl.git"),
+              PackageSpec(url="https://github.com/favba/MPASMeshes.jl.git")
+             ]
+
+Pkg.activate("cgfd-usp-mpas", shared=true)
+
+Pkg.add(pkgs)
+

--- a/usp-utils/pre_proc/grid_creation_scripts/create-voronoi-operator.jl
+++ b/usp-utils/pre_proc/grid_creation_scripts/create-voronoi-operator.jl
@@ -3,6 +3,5 @@
 using NCDatasets, Comonicon
 using VoronoiOperators
 
-const ce = Base.get_extension(VoronoiOperators, :ComoniconExt)
 
-ce.command_main(ARGS)
+VoronoiOperators.create_voronoi_operator(ARGS)

--- a/usp-utils/pre_proc/grid_creation_scripts/create-voronoi-operator.jl
+++ b/usp-utils/pre_proc/grid_creation_scripts/create-voronoi-operator.jl
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S julia --project=@cgfd-usp-mpas --threads=auto
+
+using NCDatasets, Comonicon
+using VoronoiOperators
+
+const ce = Base.get_extension(VoronoiOperators, :ComoniconExt)
+
+ce.command_main(ARGS)


### PR DESCRIPTION
This PR adds

1. The capability of reading custom operators into MPAS from a new `custom_operators` stream.
2. The option of using the cell reconstructed velocity to compute the cell kinetic energy
3. The option of using both the cell and vertex reconstructed velocities to compute the cell kinetic energy.
4. A julia script to install packages into a `@cgfd-usp-mpas` environment to be used by julia scripts
5. A julia script to create new operators and save them to a netcdf file as input to the new `custom_operators` stream.

New namelist options for the atmosphere core:

- `config_use_custom_weightsOnEdge=false` : Read new `weightsOnEdge` given in a `custom_operators` stream
- `config_use_custom_coeffs_reconstruct=false`: Read new `coeffs_reconstruct` for cell velocity reconstruction given in a `custom_operators` stream.
- `config_ke_use_reconstructed_vel=false` : Option to use the cell reconstructed velocity to compute the cell kinetic energy.
- `config_ke_use_vertex_reconstructed_vel=false` : Option to also use the vertex reconstructed velocity in addition to the cell reconstructed velocity to compute the cell kinetic energy. This option can only be used together with `config_ke_use_reconstructe_vel=true` and if a `coeffs_vertex_vel_reconstruc` weights are present in the `custom_operators` stream.

New scripts:

- `usp-utils/install_julia_environment.jl` : Creates a new julia environment called `@cgfd-usp-mpas` with necessary packages.
- `usp-utils/pre_proc/grid_creation_scripts/create-voronoi-operator.jl` : Julia script to create netcdf with custom operators to be fed to the new `custom_operators` stream. Run `./create-voronoi-operator.jl -h` for usage (after installing the `@cgfd-usp-utils` environment). 

