### PR TITLE
Add new julia script to regenerate, while fixing any issues, MPAS meshes

### DIFF
--- a/usp-utils/pre_proc/grid_creation_scripts/regenerate-mesh.jl
+++ b/usp-utils/pre_proc/grid_creation_scripts/regenerate-mesh.jl
@@ -1,0 +1,6 @@
+#!/usr/bin/env -S julia --project=@cgfd-usp-mpas --threads=auto
+
+using NCDatasets, Comonicon
+using MPASMeshes
+
+MPASMeshes.regenerate_mesh(ARGS)


### PR DESCRIPTION
The `@cgfd-usp-mpas` julia shared environment must be updated to the latest changes.

The script help message:
```
  regenerate-mesh

Regenerate the mesh given by grid and write it to output. The new mesh will have the same Voronoi
Diagram and cells / vertices ordering of the original mesh. The edge information will be completely recreated, and any
indexing problem will be fixed. Opitionally, the tangent_reconstruction string specifies which method to use
to compute the tangential velocity reconstruction weights. and the area_type string specifies the area
computation methods.

Usage

  regenerate-mesh <args> [options]

Args

  <grid>                                                    NetCDF file containing Voronoi grid information.

  <output>                                                  NetCDF file name for output mesh.



Options

  -t, --tangent-reconstruction <thuburn::String>            Edge tangential velocity reconstruction method. Available
                                                            options: "peixoto", "peixoto_old", "lsq2", and "thuburn".
                                                            Default is "thuburn".

  -a, --area-type <mimetic::String>                         Areas computation method. Available options: "geometric" for
                                                            the true geometrical area; "mimetic" for area values
                                                            suitable for the trisk mimetic scheme. Default is "mimetic".



Flags

  -h, --help                                                Print this help message.
  --version                                                 Print version.
```

