### PR TITLE
usp-utils: add NCAR-based library install + MPAS build workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,16 @@ WPS_GEOG/
 ._WPS_GEOG
 geog_*.tar.gz
 geog_*.tar.bz2
+
+# Stray per-user / HOME files created in the repo when a tool ran with HOME
+# pointing here (conda cache+envs, shell history, etc.). Never commit; the real
+# ones live in $HOME — these copies are safe to delete.
+.conda/
+.cache/
+.local/
+.config/
+.claude/
+.condarc
+.viminfo
+.python_history
+.bash_history

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,9 @@ met_data
 
 # Python compiled bytecode folders
 __pycache__
+
+# WPS geographical static data (large downloads — never commit)
+WPS_GEOG/
+._WPS_GEOG
+geog_*.tar.gz
+geog_*.tar.bz2

--- a/usp-utils/README.md
+++ b/usp-utils/README.md
@@ -18,10 +18,9 @@ Julia scipts (`.jl` files) rely on a shared environment called `cgfd-usp-mpas` w
 > **Two caveats when installing the Julia environment:**
 > - Run it with `LD_LIBRARY_PATH` cleared, otherwise Julia segfaults in this
 >   stack: `env -u LD_LIBRARY_PATH julia install_julia_environment.jl`.
-> - There is currently a temporary upstream version conflict (`Zeros` compat).
->   Until it is fixed, install with
->   `env -u LD_LIBRARY_PATH julia install_julia_environment_workaround.jl`
->   instead. See [`UPSTREAM_ISSUE_zeros_compat.md`](UPSTREAM_ISSUE_zeros_compat.md).
+> - `Pkg` may fail to resolve while favba's packages are temporarily out of sync
+>   (a `Zeros` compat conflict). If so, a temporary workaround is tracked on the
+>   `julia/zeros-compat-workaround` branch until the upstream packages are fixed.
 
 ## Installing libraries and building MPAS
 

--- a/usp-utils/README.md
+++ b/usp-utils/README.md
@@ -15,6 +15,45 @@ Pre and post processing scripts are placed in `./pre_proc` and `./post_proc` res
 
 Julia scipts (`.jl` files) rely on a shared environment called `cgfd-usp-mpas` which can be installed with the `install_julia_environment.jl` script. The same script can also be used to update the environment.
 
+> **Two caveats when installing the Julia environment:**
+> - Run it with `LD_LIBRARY_PATH` cleared, otherwise Julia segfaults in this
+>   stack: `env -u LD_LIBRARY_PATH julia install_julia_environment.jl`.
+> - There is currently a temporary upstream version conflict (`Zeros` compat).
+>   Until it is fixed, install with
+>   `env -u LD_LIBRARY_PATH julia install_julia_environment_workaround.jl`
+>   instead. See [`UPSTREAM_ISSUE_zeros_compat.md`](UPSTREAM_ISSUE_zeros_compat.md).
+
+## Installing libraries and building MPAS
+
+Beyond the pre/post-processing tooling above, `usp-utils` also helps you
+prepare a full build environment and compile the model, following the NCAR
+MPAS-Atmosphere library workflow. The recommended end-to-end flow is documented
+in **[`install/INSTALL_GUIDE.md`](install/INSTALL_GUIDE.md)**.
+
+In short, the recommended order is:
+
+1. **Conda environment** (pre/post-processing): `./install_conda_environment.sh`
+2. **Julia environment** (mesh tools, optional): see the caveats above
+3. **Source the environment**: `. setup_environment.sh`
+4. **Download library sources**: `./install/download_mpas_lib_sources.sh <dir>`
+5. **Build the I/O libraries**: copy the template to a git-ignored
+   `install/mpas_lib_install.local.sh`, set `LIBSRC`/`LIBBASE` in the copy,
+   then run it (it also builds its own MPICH — no system MPI required)
+6. **Compile MPAS**: export the build environment, then
+   `make gfortran CORE=init_atmosphere` and `make gfortran CORE=atmosphere`
+   from the repository root
+7. **Set up a run directory**:
+   `./testing_and_setup/atmosphere/setup_run_dir.py <rundir>`
+
+The `install/` directory contains the helpers for steps 4–5:
+
+- `download_mpas_lib_sources.sh` — downloads and verifies the library source
+  tarballs (the exact versions expected by the build script)
+- `mpas_lib_install.sh` — **template** that builds MPICH, zlib, HDF5, PnetCDF,
+  NetCDF-C, NetCDF-Fortran, and PIO from source. Copy it to
+  `mpas_lib_install.local.sh` (git-ignored) and set your `LIBSRC`/`LIBBASE`
+  there; the original template stays clean in the repo.
+
 ### Note to developers
 
 New python **modules** (scripts containing definitions that are imported into other scripts) should be placed into `./libs/py`, not in the same folder as the actual scripts importing it.

--- a/usp-utils/install/.gitignore
+++ b/usp-utils/install/.gitignore
@@ -1,0 +1,4 @@
+# Personal copies of the install scripts with machine-specific paths.
+# Copy a template (e.g. mpas_lib_install.sh -> mpas_lib_install.local.sh),
+# edit LIBSRC/LIBBASE, and run the .local.sh copy. These are never committed.
+*.local.sh

--- a/usp-utils/install/INSTALL_GUIDE.md
+++ b/usp-utils/install/INSTALL_GUIDE.md
@@ -21,17 +21,23 @@ directory unless stated otherwise.
 
 ## Step 0 — Check prerequisites
 
-You need a C/C++/Fortran compiler, `cmake` (for PIO), `git`, and `curl`/`wget`:
+You need a C/C++/Fortran compiler, `make`, `cmake` (for PIO), `git`,
+`curl`/`wget`, and `tar`/`gzip`/`bzip2` (HDF5 ships as `.tar.bz2`):
 
 ```sh
 gfortran --version && gcc --version && g++ --version
-cmake --version
-git --version && curl --version
+make --version && cmake --version
+git --version && curl --version && bzip2 --version
 ```
 
 For the Python/Julia tooling you also need `conda` on your `PATH`, and
 [`juliaup`](https://github.com/JuliaLang/juliaup) (or any Julia ≥ 1.10) if you
 plan to use the mesh-generation scripts.
+
+> **Two independent tracks.** Steps 1–3 set up the Python/Julia tooling for
+> pre/post-processing. Steps 4–6 build and compile the model and do **not**
+> require the conda or Julia environments — they only need the build
+> environment from Step 5. You can run them in a clean shell if you prefer.
 
 ---
 
@@ -97,7 +103,15 @@ conda environment:
 
 The model needs MPI, HDF5, PnetCDF, NetCDF-C, NetCDF-Fortran, and PIO. The
 `install/mpas_lib_install.sh` script builds them all from source — including
-its **own MPICH**, so you do not need a system MPI.
+its **own MPICH**, so you do not need a system MPI. (The template is already
+patched for gfortran ≥ 10; see Troubleshooting if you adapt it.)
+
+> **PIO is optional.** MPAS v8 ships a bundled I/O layer (SMIOL,
+> `src/external/SMIOL`) and falls back to it automatically when the `PIO`
+> environment variable is unset. The NCAR workflow here builds and uses PIO; if
+> you skip it (omit PIO from the build and leave `PIO` unset in Step 5), MPAS
+> still compiles and runs using SMIOL. `NETCDF` and `PNETCDF` are always
+> required.
 
 ### 4a. Download the source tarballs
 
@@ -150,8 +164,9 @@ Order built: MPICH → zlib → HDF5 → PnetCDF → NetCDF-C → NetCDF-Fortran
 
 `mpas_lib_install.sh` sets the needed variables, but only inside its own
 shell — they are gone once it exits. Before compiling MPAS, set them in your
-shell (adjust `LIBBASE` to the value you used above). Save this as a small
-`mpas_build_env.sh` and `source` it whenever you build:
+shell (adjust `LIBBASE` to the value you used above). Save this block as
+`install/mpas_build_env.local.sh` (git-ignored by `*.local.sh`) and `source`
+it whenever you build or run the model:
 
 ```sh
 export LIBBASE=/path/to/mpas-libs
@@ -204,8 +219,19 @@ namelists, streams, and physics lookup tables into a run directory:
 ```
 
 Then place your mesh in `grids/` and meteorological input in `met_data/`, edit
-the namelists/streams, and run `init_atmosphere_model` followed by
-`atmosphere_model`.
+the namelists/streams, and run the cores. MPAS is an MPI program, so launch it
+with `mpirun` (make sure the Step 5 environment is sourced, so the MPICH
+`mpirun` is on your `PATH`):
+
+```sh
+cd "$MPAS_ROOT/runs/my_first_run"
+mpirun -np 4 ./init_atmosphere_model     # build initial conditions
+# ... edit namelist.atmosphere / streams.atmosphere ...
+mpirun -np 4 ./atmosphere_model          # integrate the model
+```
+
+> Running `./atmosphere_model` directly with no namelist/inputs aborts via
+> `MPI_Abort` almost immediately — that is expected, not a build problem.
 
 ---
 
@@ -224,13 +250,15 @@ mkdir -p "$HOME/mpas-build/work" && cd "$HOME/mpas-build/work"
 bash "$MPAS_ROOT/usp-utils/install/mpas_lib_install.local.sh" 2>&1 | tee build.log
 
 # compile the model
-source mpas_build_env.sh          # the export block from Step 5
+source "$MPAS_ROOT/usp-utils/install/mpas_build_env.local.sh"   # export block from Step 5
 cd "$MPAS_ROOT"
 make gfortran CORE=init_atmosphere
 make clean CORE=atmosphere && make gfortran CORE=atmosphere
 
-# prepare a run
+# prepare and launch a run
 ./testing_and_setup/atmosphere/setup_run_dir.py "$MPAS_ROOT/runs/my_first_run"
+cd "$MPAS_ROOT/runs/my_first_run"
+mpirun -np 4 ./init_atmosphere_model      # then edit namelist.atmosphere and run atmosphere_model
 ```
 
 ---

--- a/usp-utils/install/INSTALL_GUIDE.md
+++ b/usp-utils/install/INSTALL_GUIDE.md
@@ -177,6 +177,44 @@ please add it here** so the next person benefits.
   that configures with `CC=mpicc` will then fail with the misleading
   `C compiler cannot create executables` (the cascade from the missing `mpicc`).
 
+### Alternative: gcc/gfortran-12 toolchain (if the model crashes at run time)
+
+The libraries build fine with gfortran 13, but **MPAS v8.4 miscompiles with
+gfortran 13** — the model compiles and then crashes at run time. gfortran 12 is
+the version the NCAR tutorial uses and produces a working model. If you hit
+unexplained run-time crashes, rebuild the I/O stack **and** the model with
+gfortran 12 from a conda env, into a separate `libs-gcc12` prefix (so your
+gfortran-13 build in `libs` is preserved):
+
+```sh
+# 1. a conda env that provides gfortran/gcc 12
+conda create -n mpas-gcc12 -c conda-forge 'gfortran=12' 'gcc=12' 'gxx=12'
+conda activate mpas-gcc12
+
+# 2. build the libs with the gcc12 template (copy to .local.sh, edit LIBSRC/LIBBASE)
+cp install/mpas_lib_install_gcc12.sh install/mpas_lib_install_gcc12.local.sh
+mkdir -p "$HOME/mpas-build/work-gcc12" && cd "$HOME/mpas-build/work-gcc12"
+bash "$MPAS_ROOT/usp-utils/install/mpas_lib_install_gcc12.local.sh" 2>&1 | tee build-gcc12.log
+```
+
+Then use this build environment instead of the Step 5 block (keep `mpas-gcc12`
+active so the conda `libgfortran.so.5` is found **at both compile and run time**);
+save it as `install/mpas_build_env_gcc12.local.sh` (git-ignored) and `source` it:
+
+```sh
+export LIBBASE=$HOME/mpas-build/libs-gcc12
+GCC12_ENV="${CONDA_PREFIX:?conda activate mpas-gcc12 first}"   # the active gcc12 env
+export PATH="$LIBBASE/bin:$GCC12_ENV/bin:$PATH"        # MPICH wrappers + conda gfortran-12
+export LD_LIBRARY_PATH="$LIBBASE/lib:$GCC12_ENV/lib:${LD_LIBRARY_PATH:-}"
+export NETCDF="$LIBBASE"
+export PNETCDF="$LIBBASE"
+export PIO="$LIBBASE"
+export MPAS_EXTERNAL_LIBS="-L$LIBBASE/lib -lhdf5_hl -lhdf5 -ldl -lz"
+export MPAS_EXTERNAL_INCLUDES="-I$LIBBASE/include"
+```
+
+Then compile as in Step 6. The rest of the workflow is unchanged.
+
 ---
 
 ## Step 5 — Export the build environment

--- a/usp-utils/install/INSTALL_GUIDE.md
+++ b/usp-utils/install/INSTALL_GUIDE.md
@@ -103,8 +103,9 @@ conda environment:
 
 The model needs MPI, HDF5, PnetCDF, NetCDF-C, NetCDF-Fortran, and PIO. The
 `install/mpas_lib_install.sh` script builds them all from source — including
-its **own MPICH**, so you do not need a system MPI. (The template is already
-patched for gfortran ≥ 10; see Troubleshooting if you adapt it.)
+its **own MPICH**, so you do not need a system MPI. It is kept as the
+**unmodified NCAR script** — try it as-is first; if a step fails, see
+[Known build issues (optional fixes)](#known-build-issues-optional-fixes) below.
 
 > **PIO is optional.** MPAS v8 ships a bundled I/O layer (SMIOL,
 > `src/external/SMIOL`) and falls back to it automatically when the `PIO`
@@ -157,6 +158,28 @@ bash /full/path/to/usp-utils/install/mpas_lib_install.local.sh 2>&1 | tee mpas_l
 ```
 
 Order built: MPICH → zlib → HDF5 → PnetCDF → NetCDF-C → NetCDF-Fortran → PIO.
+
+### Known build issues (optional fixes)
+
+Run the unmodified script first. If a step fails, the fixes below have worked
+for us — apply them **in your `.local.sh` copy**, not in the versioned template.
+They depend on the compiler/OS, so they are not guaranteed to be the right fix
+on every system. **If you hit a build failure and find a different solution,
+please add it here** so the next person benefits.
+
+- **MPICH configure fails on the Fortran check** with
+  `gfortran allows mismatched arguments... no` /
+  `configure: error: The Fortran compiler gfortran will not compile files that`
+  `call the same routine with arguments of different types` — this happens with
+  **gfortran ≥ 10**, because MPICH 3.3.1's F77 check uses `FFLAGS`, which in the
+  original script does not carry the needed flag. Add
+  `-fallow-argument-mismatch` to `FFLAGS` in your `.local.sh`:
+  ```sh
+  export FFLAGS="-g -fbacktrace -fallow-argument-mismatch"
+  ```
+  *Verified on gfortran 13.3.* If MPICH does not build, every later library
+  that configures with `CC=mpicc` will then fail with the misleading
+  `C compiler cannot create executables` (the cascade from the missing `mpicc`).
 
 ---
 
@@ -275,10 +298,9 @@ mpirun -np 4 ./init_atmosphere_model      # then edit namelist.atmosphere and ru
   (Step 5).
 - **Library build fails with `C compiler cannot create executables`** — this is almost
   always a *cascade*: MPICH failed to build first (so `mpicc` is missing), and the later
-  libs that use `CC=mpicc` then can't link. Scroll up to the MPICH step. With gfortran
-  ≥ 10 the real error there is `gfortran allows mismatched arguments... no /
-  configure: error: The Fortran compiler gfortran will not compile files that call the
-  same routine with arguments of different types`. Fix: ensure `FFLAGS` includes
-  `-fallow-argument-mismatch` (already set in `mpas_lib_install.sh`).
+  libs that use `CC=mpicc` then can't link. Scroll up to the MPICH step — with gfortran
+  ≥ 10 the real error there is the Fortran mismatched-arguments check. See
+  [Known build issues (optional fixes)](#known-build-issues-optional-fixes) for the
+  `FFLAGS` fix to apply in your `.local.sh`.
 - **Switching to a branch that changes `src/`** — rebuild; the on-disk binary is not
   recompiled automatically and is not tracked by git.

--- a/usp-utils/install/INSTALL_GUIDE.md
+++ b/usp-utils/install/INSTALL_GUIDE.md
@@ -68,16 +68,12 @@ The `.jl` scripts rely on a **shared** Julia environment, also called
 >    ```sh
 >    env -u LD_LIBRARY_PATH julia install_julia_environment.jl
 >    ```
-> 2. **Temporary upstream version conflict.** As of this writing, favba's
->    `TensorsLite` requires `Zeros 0.5` while `VoronoiMeshes`/`MPASMeshes`
->    still pin `Zeros 0.4`, so the resolve fails. Until that is fixed
->    upstream, use the workaround installer instead:
->    ```sh
->    env -u LD_LIBRARY_PATH julia install_julia_environment_workaround.jl
->    ```
->    See `usp-utils/UPSTREAM_ISSUE_zeros_compat.md` for details and the
->    one-line upstream fix. Once upstream is fixed, go back to
->    `install_julia_environment.jl`.
+> 2. **Possible upstream version conflict.** `Pkg` may fail to resolve when
+>    favba's packages are temporarily out of sync (e.g. a `Zeros` compat
+>    mismatch between `TensorsLite` and `VoronoiMeshes`/`MPASMeshes`). If you
+>    hit that, a temporary workaround is tracked separately on the
+>    `julia/zeros-compat-workaround` branch — use it (or check with the team)
+>    until the upstream packages are back in sync.
 
 To **run** the mesh scripts afterwards you do *not* need to activate anything
 manually — they select the shared environment via their shebang
@@ -263,7 +259,7 @@ mpirun -np 4 ./atmosphere_model          # integrate the model
 ```sh
 # one-time environment setup
 ./install_conda_environment.sh
-env -u LD_LIBRARY_PATH julia install_julia_environment_workaround.jl   # or the non-workaround once upstream is fixed
+env -u LD_LIBRARY_PATH julia install_julia_environment.jl   # see Step 2 if Pkg fails to resolve (Zeros conflict)
 . setup_environment.sh
 
 # build the I/O libraries (NCAR workflow)
@@ -290,8 +286,8 @@ mpirun -np 4 ./init_atmosphere_model      # then edit namelist.atmosphere and ru
 
 - **Julia segfaults during `Pkg` operations** — clear `LD_LIBRARY_PATH`:
   `env -u LD_LIBRARY_PATH julia ...` (see Step 2).
-- **Julia resolve fails on `Zeros`** — use `install_julia_environment_workaround.jl`
-  (see Step 2 and `UPSTREAM_ISSUE_zeros_compat.md`).
+- **Julia resolve fails on `Zeros`** — temporary upstream conflict; see Step 2 and the
+  `julia/zeros-compat-workaround` branch.
 - **`make` can't find `mpif90`/`mpicc`** — `$LIBBASE/bin` is not on `PATH`; re-source
   the Step 5 environment.
 - **`ERROR: The PNETCDF environment variable isn't set.`** — export `PNETCDF=$LIBBASE`

--- a/usp-utils/install/INSTALL_GUIDE.md
+++ b/usp-utils/install/INSTALL_GUIDE.md
@@ -1,0 +1,256 @@
+# Installing libraries and building MPAS — recommended workflow
+
+This guide walks you, end to end, through preparing the environment and
+compiling the MPAS model on a fresh Linux machine, following the **NCAR
+MPAS-Atmosphere tutorial** approach for the I/O libraries.
+
+There are two independent concerns; you can do both or just the one you need:
+
+| Concern | What it is for | Tooling |
+|---------|----------------|---------|
+| **Python / Julia environments** | pre- and post-processing: mesh creation, plotting, NetCDF handling | conda + Julia |
+| **C/Fortran build toolchain** | actually compiling `init_atmosphere_model` and `atmosphere_model` | MPICH + HDF5 + (Pn)etCDF + PIO, then `make` |
+
+> You can compile MPAS **without** conda/Julia, but you will need them to
+> generate Voronoi meshes and to process model I/O for real runs.
+
+All commands below assume you start from the repository's `usp-utils/`
+directory unless stated otherwise.
+
+---
+
+## Step 0 — Check prerequisites
+
+You need a C/C++/Fortran compiler, `cmake` (for PIO), `git`, and `curl`/`wget`:
+
+```sh
+gfortran --version && gcc --version && g++ --version
+cmake --version
+git --version && curl --version
+```
+
+For the Python/Julia tooling you also need `conda` on your `PATH`, and
+[`juliaup`](https://github.com/JuliaLang/juliaup) (or any Julia ≥ 1.10) if you
+plan to use the mesh-generation scripts.
+
+---
+
+## Step 1 — Conda environment (pre/post-processing)
+
+Run once. Creates the `cgfd-usp-mpas` conda environment from
+`libs/cgfd-usp-mpas.yml`:
+
+```sh
+./install_conda_environment.sh
+```
+
+Re-running it later updates the environment instead.
+
+---
+
+## Step 2 — Julia environment (only if you use the `.jl` mesh tools)
+
+The `.jl` scripts rely on a **shared** Julia environment, also called
+`cgfd-usp-mpas`.
+
+> **Important — two known gotchas on this stack:**
+>
+> 1. **Segfault from `LD_LIBRARY_PATH`.** In the MPAS/conda environment,
+>    `LD_LIBRARY_PATH` shadows Julia's bundled libraries and crashes `Pkg`
+>    during network/git operations. Always install/update the Julia
+>    environment with that variable cleared:
+>    ```sh
+>    env -u LD_LIBRARY_PATH julia install_julia_environment.jl
+>    ```
+> 2. **Temporary upstream version conflict.** As of this writing, favba's
+>    `TensorsLite` requires `Zeros 0.5` while `VoronoiMeshes`/`MPASMeshes`
+>    still pin `Zeros 0.4`, so the resolve fails. Until that is fixed
+>    upstream, use the workaround installer instead:
+>    ```sh
+>    env -u LD_LIBRARY_PATH julia install_julia_environment_workaround.jl
+>    ```
+>    See `usp-utils/UPSTREAM_ISSUE_zeros_compat.md` for details and the
+>    one-line upstream fix. Once upstream is fixed, go back to
+>    `install_julia_environment.jl`.
+
+To **run** the mesh scripts afterwards you do *not* need to activate anything
+manually — they select the shared environment via their shebang
+(`--project=@cgfd-usp-mpas`). Running the scripts (as opposed to installing
+packages) does not trigger the segfault, so no `LD_LIBRARY_PATH` handling is
+needed at run time.
+
+---
+
+## Step 3 — Source the environment
+
+This sets `MPAS_ROOT`, creates the `runs/`, `grids/`, and `met_data/`
+directories, puts the helper Python modules on `PYTHONPATH`, and activates the
+conda environment:
+
+```sh
+. setup_environment.sh      # or setup_environment.fish for the fish shell
+```
+
+---
+
+## Step 4 — Build the I/O libraries (NCAR workflow)
+
+The model needs MPI, HDF5, PnetCDF, NetCDF-C, NetCDF-Fortran, and PIO. The
+`install/mpas_lib_install.sh` script builds them all from source — including
+its **own MPICH**, so you do not need a system MPI.
+
+### 4a. Download the source tarballs
+
+```sh
+./install/download_mpas_lib_sources.sh /path/to/sources
+# default if omitted: $HOME/mpas-build/sources
+```
+
+This fetches the six tarballs in the exact versions `mpas_lib_install.sh`
+expects, verifies their integrity, and writes a `SHA256SUMS` manifest. Pass
+`--with-pio` to also pre-clone `NCAR/ParallelIO` (otherwise the install script
+clones it itself at build time).
+
+### 4b. Point the install script at your paths
+
+`mpas_lib_install.sh` is a **versioned template** with placeholder paths — do
+not edit it in place. Instead copy it to a personal `*.local.sh` (these are
+git-ignored, so your machine-specific paths never get committed):
+
+```sh
+cp install/mpas_lib_install.sh install/mpas_lib_install.local.sh
+```
+
+Then edit the two paths at the top of your `mpas_lib_install.local.sh`:
+
+```sh
+export LIBSRC=/path/to/sources       # same directory you downloaded into
+export LIBBASE=/path/to/mpas-libs    # writable install prefix for the libs
+```
+
+> Pick a disk with room for both (the build is sizeable). E.g.
+> `LIBSRC=$HOME/mpas-build/sources`, `LIBBASE=$HOME/mpas-build/libs`, or a
+> scratch disk like `/p1-swell/<user>/mpas-build/...`.
+
+### 4c. Run the build
+
+Run it from an empty working directory (it extracts the tarballs into the
+current directory and cleans up as it goes):
+
+```sh
+mkdir -p /path/to/build_work && cd /path/to/build_work
+bash /full/path/to/usp-utils/install/mpas_lib_install.local.sh 2>&1 | tee mpas_lib_build.log
+```
+
+Order built: MPICH → zlib → HDF5 → PnetCDF → NetCDF-C → NetCDF-Fortran → PIO.
+
+---
+
+## Step 5 — Export the build environment
+
+`mpas_lib_install.sh` sets the needed variables, but only inside its own
+shell — they are gone once it exits. Before compiling MPAS, set them in your
+shell (adjust `LIBBASE` to the value you used above). Save this as a small
+`mpas_build_env.sh` and `source` it whenever you build:
+
+```sh
+export LIBBASE=/path/to/mpas-libs
+export PATH="$LIBBASE/bin:$PATH"                 # so make finds the MPICH mpif90/mpicc
+export LD_LIBRARY_PATH="$LIBBASE/lib:$LD_LIBRARY_PATH"
+export NETCDF="$LIBBASE"
+export PNETCDF="$LIBBASE"
+export PIO="$LIBBASE"
+export MPAS_EXTERNAL_LIBS="-L$LIBBASE/lib -lhdf5_hl -lhdf5 -ldl -lz"
+export MPAS_EXTERNAL_INCLUDES="-I$LIBBASE/include"
+```
+
+Verify the MPI wrappers are found:
+
+```sh
+which mpif90 mpicc      # should point inside $LIBBASE/bin
+```
+
+---
+
+## Step 6 — Compile MPAS
+
+From the **repository root** (`$MPAS_ROOT`), build the two atmosphere cores.
+The `gfortran` target uses the MPICH wrappers (`mpif90`/`mpicc`):
+
+```sh
+cd "$MPAS_ROOT"
+make gfortran CORE=init_atmosphere
+make clean    CORE=atmosphere      # clean shared objects between cores
+make gfortran CORE=atmosphere
+```
+
+Useful options: `PRECISION=double`, `DEBUG=true`, `OPENMP=true`. (`gnu` is an
+alias of the `gfortran` target.)
+
+On success you get the executables `init_atmosphere_model` and
+`atmosphere_model` in the repository root. They are git-ignored build
+artifacts, so they persist on disk across branch switches in the same working
+directory (valid as long as `src/` is unchanged).
+
+---
+
+## Step 7 — Set up a run directory
+
+Use the helper to link the freshly built executables and copy the default
+namelists, streams, and physics lookup tables into a run directory:
+
+```sh
+./testing_and_setup/atmosphere/setup_run_dir.py "$MPAS_ROOT/runs/my_first_run"
+```
+
+Then place your mesh in `grids/` and meteorological input in `met_data/`, edit
+the namelists/streams, and run `init_atmosphere_model` followed by
+`atmosphere_model`.
+
+---
+
+## Quick reference (the whole flow)
+
+```sh
+# one-time environment setup
+./install_conda_environment.sh
+env -u LD_LIBRARY_PATH julia install_julia_environment_workaround.jl   # or the non-workaround once upstream is fixed
+. setup_environment.sh
+
+# build the I/O libraries (NCAR workflow)
+./install/download_mpas_lib_sources.sh "$HOME/mpas-build/sources"
+cp install/mpas_lib_install.sh install/mpas_lib_install.local.sh   # then edit LIBSRC/LIBBASE in the copy
+mkdir -p "$HOME/mpas-build/work" && cd "$HOME/mpas-build/work"
+bash "$MPAS_ROOT/usp-utils/install/mpas_lib_install.local.sh" 2>&1 | tee build.log
+
+# compile the model
+source mpas_build_env.sh          # the export block from Step 5
+cd "$MPAS_ROOT"
+make gfortran CORE=init_atmosphere
+make clean CORE=atmosphere && make gfortran CORE=atmosphere
+
+# prepare a run
+./testing_and_setup/atmosphere/setup_run_dir.py "$MPAS_ROOT/runs/my_first_run"
+```
+
+---
+
+## Troubleshooting
+
+- **Julia segfaults during `Pkg` operations** — clear `LD_LIBRARY_PATH`:
+  `env -u LD_LIBRARY_PATH julia ...` (see Step 2).
+- **Julia resolve fails on `Zeros`** — use `install_julia_environment_workaround.jl`
+  (see Step 2 and `UPSTREAM_ISSUE_zeros_compat.md`).
+- **`make` can't find `mpif90`/`mpicc`** — `$LIBBASE/bin` is not on `PATH`; re-source
+  the Step 5 environment.
+- **`ERROR: The PNETCDF environment variable isn't set.`** — export `PNETCDF=$LIBBASE`
+  (Step 5).
+- **Library build fails with `C compiler cannot create executables`** — this is almost
+  always a *cascade*: MPICH failed to build first (so `mpicc` is missing), and the later
+  libs that use `CC=mpicc` then can't link. Scroll up to the MPICH step. With gfortran
+  ≥ 10 the real error there is `gfortran allows mismatched arguments... no /
+  configure: error: The Fortran compiler gfortran will not compile files that call the
+  same routine with arguments of different types`. Fix: ensure `FFLAGS` includes
+  `-fallow-argument-mismatch` (already set in `mpas_lib_install.sh`).
+- **Switching to a branch that changes `src/`** — rebuild; the on-disk binary is not
+  recompiled automatically and is not tracked by git.

--- a/usp-utils/install/download_mpas_lib_sources.sh
+++ b/usp-utils/install/download_mpas_lib_sources.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# download_mpas_lib_sources.sh
+#
+# Download the source tarballs required by the NCAR MPAS library build
+# (mpas_lib_install.sh). Versions here MUST match the ones expanded by that
+# script, otherwise the `cd <dir>` steps will fail.
+#
+# Most sources come from the NCAR/MMM mirror used by the MPAS-Atmosphere
+# tutorial (http://www2.mmm.ucar.edu/people/duda/files/mpas/sources/). The
+# PnetCDF tarball is not on that mirror, so it is fetched from the official
+# Parallel-netCDF release site.
+#
+# PIO is NOT downloaded here: mpas_lib_install.sh clones NCAR/ParallelIO
+# (tag pio2_5_8) directly. Pass --with-pio to also stage that clone locally.
+#
+# Usage:
+#   ./download_mpas_lib_sources.sh [LIBSRC_DIR] [--with-pio]
+#
+#   LIBSRC_DIR  Directory to download into (default: $HOME/mpas-build/sources,
+#               or the LIBSRC env var if set). Point mpas_lib_install.sh's
+#               LIBSRC variable at this same directory.
+#
+# The script is idempotent: a file that already exists and passes its archive
+# integrity check is skipped (so it doubles as a resume/verify tool).
+
+set -uo pipefail
+
+CYAN='\033[0;36m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+INFO="${CYAN}[INFO]${NC}"; WARN="${YELLOW}[WARN]${NC}"; ERR="${RED}[ERROR]${NC}"; OK="${GREEN}[OK]${NC}"
+
+# --- Argument parsing ---------------------------------------------------------
+CLONE_PIO=0
+LIBSRC="${LIBSRC:-$HOME/mpas-build/sources}"
+for arg in "$@"; do
+    case "$arg" in
+        --with-pio) CLONE_PIO=1 ;;
+        -h|--help)  grep '^#' "$0" | sed 's/^# \?//'; exit 0 ;;
+        *)          LIBSRC="$arg" ;;
+    esac
+done
+
+NCAR="https://www2.mmm.ucar.edu/people/duda/files/mpas/sources"
+PNETCDF_SRC="https://parallel-netcdf.github.io/Release"
+
+# filename|download_url  (versions must match mpas_lib_install.sh)
+FILES=(
+    "mpich-3.3.1.tar.gz|${NCAR}/mpich-3.3.1.tar.gz"
+    "zlib-1.2.11.tar.gz|${NCAR}/zlib-1.2.11.tar.gz"
+    "hdf5-1.10.5.tar.bz2|${NCAR}/hdf5-1.10.5.tar.bz2"
+    "pnetcdf-1.12.2.tar.gz|${PNETCDF_SRC}/pnetcdf-1.12.2.tar.gz"
+    "netcdf-c-4.6.3.tar.gz|${NCAR}/netcdf-c-4.6.3.tar.gz"
+    "netcdf-fortran-4.5.2.tar.gz|${NCAR}/netcdf-fortran-4.5.2.tar.gz"
+)
+
+# --- Helpers ------------------------------------------------------------------
+# Verify a downloaded archive is not truncated/corrupt.
+verify_archive() {
+    local f="$1"
+    case "$f" in
+        *.tar.gz)  gzip  -t "$f" 2>/dev/null ;;
+        *.tar.bz2) bzip2 -t "$f" 2>/dev/null ;;
+        *)         return 0 ;;
+    esac
+}
+
+# --- Download -----------------------------------------------------------------
+mkdir -p "$LIBSRC"
+echo -e "${INFO} Downloading MPAS library sources into: ${LIBSRC}"
+echo -e "${INFO} (set LIBSRC=${LIBSRC} in mpas_lib_install.sh)"
+
+failures=0
+for entry in "${FILES[@]}"; do
+    fname="${entry%%|*}"
+    url="${entry#*|}"
+    dest="${LIBSRC}/${fname}"
+
+    if [ -f "$dest" ] && verify_archive "$dest"; then
+        echo -e "${OK} ${fname} already present and valid — skipping"
+        continue
+    fi
+
+    echo -e "${INFO} Fetching ${fname}"
+    # -L follow redirects, -f fail on HTTP error, -C - resume, --retry transient errors
+    if ! curl -fL -C - --retry 3 --retry-delay 5 -o "$dest" "$url"; then
+        echo -e "${ERR} Download failed: ${fname} (${url})"
+        rm -f "$dest"
+        failures=$((failures+1))
+        continue
+    fi
+
+    if ! verify_archive "$dest"; then
+        echo -e "${ERR} Integrity check failed (corrupt/truncated): ${fname}"
+        rm -f "$dest"
+        failures=$((failures+1))
+        continue
+    fi
+    echo -e "${OK} ${fname}"
+done
+
+# --- Optional: stage ParallelIO (PIO) -----------------------------------------
+if [ "$CLONE_PIO" -eq 1 ]; then
+    echo -e "${INFO} Staging ParallelIO (tag pio2_5_8)"
+    if [ -d "${LIBSRC}/ParallelIO" ]; then
+        echo -e "${OK} ParallelIO clone already present — skipping"
+    elif git clone --quiet https://github.com/NCAR/ParallelIO "${LIBSRC}/ParallelIO" \
+         && git -C "${LIBSRC}/ParallelIO" checkout --quiet -b pio-2.5.8 pio2_5_8; then
+        echo -e "${OK} ParallelIO @ pio2_5_8"
+    else
+        echo -e "${ERR} Failed to clone/checkout ParallelIO"
+        failures=$((failures+1))
+    fi
+fi
+
+# --- Provenance manifest (sha256) ---------------------------------------------
+echo -e "${INFO} Recording checksums in ${LIBSRC}/SHA256SUMS"
+( cd "$LIBSRC" && sha256sum *.tar.gz *.tar.bz2 2>/dev/null > SHA256SUMS )
+
+echo ""
+if [ "$failures" -eq 0 ]; then
+    echo -e "${OK} All sources downloaded and verified in ${LIBSRC}"
+    echo -e "${INFO} Next: edit mpas_lib_install.sh (set LIBSRC and a writable LIBBASE), then run it."
+    exit 0
+else
+    echo -e "${ERR} ${failures} download(s) failed — see messages above."
+    exit 1
+fi

--- a/usp-utils/install/mpas_lib_install.sh
+++ b/usp-utils/install/mpas_lib_install.sh
@@ -30,11 +30,7 @@ export FC=$SERIAL_FC
 unset F90  # This seems to be set by default on NCAR's Cheyenne and is problematic
 unset F90FLAGS
 export CFLAGS="-g"
-# -fallow-argument-mismatch is required for gfortran >= 10 (MPICH 3.3.1's F77
-# checks use FFLAGS); without it MPICH configure fails the mismatched-arguments
-# test and never builds, which cascades into "C compiler cannot create
-# executables" in the later libs that use the (then-missing) mpicc.
-export FFLAGS="-g -fbacktrace -fallow-argument-mismatch"
+export FFLAGS="-g -fbacktrace"
 export FCFLAGS="-g -fbacktrace -fallow-argument-mismatch"
 export F77FLAGS="-g -fbacktrace -fallow-argument-mismatch"
 

--- a/usp-utils/install/mpas_lib_install.sh
+++ b/usp-utils/install/mpas_lib_install.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+#
+# Sources for all libraries used in this script can be found at
+# http://www2.mmm.ucar.edu/people/duda/files/mpas/sources/ 
+#
+
+# Where to find sources for libraries - generally, the directory into which
+# you have downloaded the sources from the URL, above
+export LIBSRC=/sysdisk2/duda/sources
+
+# Where to install libraries - this directory must be writable by you
+export LIBBASE=/sysdisk2/duda/mpas-libs
+
+# Compilers
+export SERIAL_FC=gfortran
+export SERIAL_F77=gfortran
+export SERIAL_CC=gcc
+export SERIAL_CXX=g++
+export MPI_FC=mpifort
+export MPI_F77=mpifort
+export MPI_CC=mpicc
+export MPI_CXX=mpic++
+
+
+export CC=$SERIAL_CC
+export CXX=$SERIAL_CXX
+export F77=$SERIAL_F77
+export FC=$SERIAL_FC
+unset F90  # This seems to be set by default on NCAR's Cheyenne and is problematic
+unset F90FLAGS
+export CFLAGS="-g"
+# -fallow-argument-mismatch is required for gfortran >= 10 (MPICH 3.3.1's F77
+# checks use FFLAGS); without it MPICH configure fails the mismatched-arguments
+# test and never builds, which cascades into "C compiler cannot create
+# executables" in the later libs that use the (then-missing) mpicc.
+export FFLAGS="-g -fbacktrace -fallow-argument-mismatch"
+export FCFLAGS="-g -fbacktrace -fallow-argument-mismatch"
+export F77FLAGS="-g -fbacktrace -fallow-argument-mismatch"
+
+
+########################################
+# MPICH
+########################################
+tar xzvf ${LIBSRC}/mpich-3.3.1.tar.gz 
+cd mpich-3.3.1
+./configure --prefix=${LIBBASE}
+make -j 4
+#make check
+make install
+#make testing
+export PATH=${LIBBASE}/bin:$PATH
+export LD_LIBRARY_PATH=${LIBBASE}/lib:$LD_LIBRARY_PATH
+cd ..
+rm -rf mpich-3.3.1
+
+########################################
+# zlib
+########################################
+tar xzvf ${LIBSRC}/zlib-1.2.11.tar.gz
+cd zlib-1.2.11
+./configure --prefix=${LIBBASE} --static
+make -j 4
+make install
+cd ..
+rm -rf zlib-1.2.11
+
+########################################
+# HDF5
+########################################
+tar xjvf ${LIBSRC}/hdf5-1.10.5.tar.bz2
+cd hdf5-1.10.5
+export FC=$MPI_FC
+export CC=$MPI_CC
+export CXX=$MPI_CXX
+./configure --prefix=${LIBBASE} --enable-parallel --with-zlib=${LIBBASE} --disable-shared
+make -j 4
+#make check
+make install
+cd ..
+rm -rf hdf5-1.10.5
+
+########################################
+# Parallel-netCDF
+########################################
+tar xzvf ${LIBSRC}/pnetcdf-1.12.2.tar.gz
+cd pnetcdf-1.12.2
+export CC=$SERIAL_CC
+export CXX=$SERIAL_CXX
+export F77=$SERIAL_F77
+export FC=$SERIAL_FC
+export MPICC=$MPI_CC
+export MPICXX=$MPI_CXX
+export MPIF77=$MPI_F77
+export MPIF90=$MPI_FC
+### Will also need gcc in path
+./configure --prefix=${LIBBASE}
+make -j 4
+#make check
+#make ptest
+#make testing
+make install
+export PNETCDF=${LIBBASE}
+cd ..
+rm -rf pnetcdf-1.12.2
+
+########################################
+# netCDF (C library)
+########################################
+tar xzvf ${LIBSRC}/netcdf-c-4.6.3.tar.gz
+cd netcdf-c-4.6.3
+export CPPFLAGS="-I${LIBBASE}/include"
+export LDFLAGS="-L${LIBBASE}/lib"
+export LIBS="-lhdf5_hl -lhdf5 -lz -ldl"
+export CC=$MPI_CC
+./configure --prefix=${LIBBASE} --disable-dap --enable-netcdf4 --enable-pnetcdf --enable-cdf5 --enable-parallel-tests --disable-shared
+make -j 4 
+#make check
+make install
+export NETCDF=${LIBBASE}
+cd ..
+rm -rf netcdf-c-4.6.3
+
+########################################
+# netCDF (Fortran interface library)
+########################################
+tar xzvf ${LIBSRC}/netcdf-fortran-4.5.2.tar.gz
+cd netcdf-fortran-4.5.2
+export FC=$MPI_FC
+export F77=$MPI_F77
+export LIBS="-lnetcdf -lpnetcdf ${LIBS}"
+./configure --prefix=${LIBBASE} --enable-parallel-tests --disable-shared
+make -j 4
+#make check
+make install
+cd ..
+rm -rf netcdf-fortran-4.5.2
+
+########################################
+# PIO
+########################################
+git clone https://github.com/NCAR/ParallelIO
+cd ParallelIO
+git checkout -b pio-2.5.8 pio2_5_8
+export PIOSRC=`pwd`
+cd ..
+mkdir pio
+cd pio
+export CC=$MPI_CC
+export FC=$MPI_FC
+cmake -DNetCDF_C_PATH=$NETCDF -DNetCDF_Fortran_PATH=$NETCDF -DPnetCDF_PATH=$PNETCDF -DHDF5_PATH=$NETCDF -DCMAKE_INSTALL_PREFIX=$LIBBASE -DPIO_USE_MALLOC=ON -DCMAKE_VERBOSE_MAKEFILE=1 -DPIO_ENABLE_TIMING=OFF $PIOSRC
+make
+#make check
+make install
+cd ..
+rm -rf pio ParallelIO
+export PIO=$LIBBASE
+
+########################################
+# Other environment vars needed by MPAS
+########################################
+export MPAS_EXTERNAL_LIBS="-L${LIBBASE}/lib -lhdf5_hl -lhdf5 -ldl -lz"
+export MPAS_EXTERNAL_INCLUDES="-I${LIBBASE}/include"

--- a/usp-utils/install/mpas_lib_install_gcc12.sh
+++ b/usp-utils/install/mpas_lib_install_gcc12.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+
+#
+# gcc/gfortran-12 variant of mpas_lib_install.sh.
+#
+# Why: MPAS v8.4 miscompiles with gfortran 13 (the model builds but crashes at
+# run time); gfortran 12 is the version the NCAR MPAS tutorial uses and builds a
+# working model. This script builds the I/O library stack with gcc/gfortran 12
+# from a conda env, into a SEPARATE prefix (libs-gcc12) so a gfortran-13 build in
+# ../libs is preserved.
+#
+# Prerequisites: a conda env that provides gcc/gfortran 12, e.g.
+#   conda create -n mpas-gcc12 -c conda-forge 'gfortran=12' 'gcc=12' 'gxx=12'
+#   conda activate mpas-gcc12
+#
+# This is a versioned TEMPLATE with placeholder paths — do not edit in place.
+# Copy it to a personal *.local.sh (git-ignored) and edit LIBSRC/LIBBASE there:
+#   cp install/mpas_lib_install_gcc12.sh install/mpas_lib_install_gcc12.local.sh
+#
+# Sources for all libraries used in this script can be found at
+# http://www2.mmm.ucar.edu/people/duda/files/mpas/sources/
+#
+
+# Where to find sources for libraries - generally, the directory into which
+# you have downloaded the sources from the URL, above
+export LIBSRC=$HOME/mpas-build/sources
+
+# Where to install libraries - this directory must be writable by you
+# (separate prefix so a gfortran-13 build in ../libs is preserved)
+export LIBBASE=$HOME/mpas-build/libs-gcc12
+
+# Compilers — gcc/gfortran 12 from the active conda env (e.g. 'mpas-gcc12').
+# These are the conda-forge compiler wrapper names; activate the env first.
+export SERIAL_FC=x86_64-conda-linux-gnu-gfortran
+export SERIAL_F77=x86_64-conda-linux-gnu-gfortran
+export SERIAL_CC=x86_64-conda-linux-gnu-gcc
+export SERIAL_CXX=x86_64-conda-linux-gnu-g++
+export MPI_FC=mpifort
+export MPI_F77=mpifort
+export MPI_CC=mpicc
+export MPI_CXX=mpic++
+
+
+export CC=$SERIAL_CC
+export CXX=$SERIAL_CXX
+export F77=$SERIAL_F77
+export FC=$SERIAL_FC
+unset F90  # This seems to be set by default on NCAR's Cheyenne and is problematic
+unset F90FLAGS
+export CFLAGS="-g"
+# gfortran >= 10 (incl. 12) needs -fallow-argument-mismatch in FFLAGS for MPICH 3.3.1
+export FFLAGS="-g -fbacktrace -fallow-argument-mismatch"
+export FCFLAGS="-g -fbacktrace -fallow-argument-mismatch"
+export F77FLAGS="-g -fbacktrace -fallow-argument-mismatch"
+
+
+########################################
+# MPICH
+########################################
+tar xzvf ${LIBSRC}/mpich-3.3.1.tar.gz
+cd mpich-3.3.1
+./configure --prefix=${LIBBASE}
+make -j 4
+#make check
+make install
+#make testing
+export PATH=${LIBBASE}/bin:$PATH
+export LD_LIBRARY_PATH=${LIBBASE}/lib:$LD_LIBRARY_PATH
+cd ..
+rm -rf mpich-3.3.1
+
+########################################
+# zlib
+########################################
+tar xzvf ${LIBSRC}/zlib-1.2.11.tar.gz
+cd zlib-1.2.11
+./configure --prefix=${LIBBASE} --static
+make -j 4
+make install
+cd ..
+rm -rf zlib-1.2.11
+
+########################################
+# HDF5
+########################################
+tar xjvf ${LIBSRC}/hdf5-1.10.5.tar.bz2
+cd hdf5-1.10.5
+export FC=$MPI_FC
+export CC=$MPI_CC
+export CXX=$MPI_CXX
+./configure --prefix=${LIBBASE} --enable-parallel --with-zlib=${LIBBASE} --disable-shared
+make -j 4
+#make check
+make install
+cd ..
+rm -rf hdf5-1.10.5
+
+########################################
+# Parallel-netCDF
+########################################
+tar xzvf ${LIBSRC}/pnetcdf-1.12.2.tar.gz
+cd pnetcdf-1.12.2
+export CC=$SERIAL_CC
+export CXX=$SERIAL_CXX
+export F77=$SERIAL_F77
+export FC=$SERIAL_FC
+export MPICC=$MPI_CC
+export MPICXX=$MPI_CXX
+export MPIF77=$MPI_F77
+export MPIF90=$MPI_FC
+### Will also need gcc in path
+./configure --prefix=${LIBBASE}
+make -j 4
+#make check
+#make ptest
+#make testing
+make install
+export PNETCDF=${LIBBASE}
+cd ..
+rm -rf pnetcdf-1.12.2
+
+########################################
+# netCDF (C library)
+########################################
+tar xzvf ${LIBSRC}/netcdf-c-4.6.3.tar.gz
+cd netcdf-c-4.6.3
+export CPPFLAGS="-I${LIBBASE}/include"
+export LDFLAGS="-L${LIBBASE}/lib"
+export LIBS="-lhdf5_hl -lhdf5 -lz -ldl"
+export CC=$MPI_CC
+./configure --prefix=${LIBBASE} --disable-dap --enable-netcdf4 --enable-pnetcdf --enable-cdf5 --enable-parallel-tests --disable-shared
+make -j 4
+#make check
+make install
+export NETCDF=${LIBBASE}
+cd ..
+rm -rf netcdf-c-4.6.3
+
+########################################
+# netCDF (Fortran interface library)
+########################################
+tar xzvf ${LIBSRC}/netcdf-fortran-4.5.2.tar.gz
+cd netcdf-fortran-4.5.2
+export FC=$MPI_FC
+export F77=$MPI_F77
+export LIBS="-lnetcdf -lpnetcdf ${LIBS}"
+./configure --prefix=${LIBBASE} --enable-parallel-tests --disable-shared
+make -j 4
+#make check
+make install
+cd ..
+rm -rf netcdf-fortran-4.5.2
+
+########################################
+# PIO
+########################################
+git clone https://github.com/NCAR/ParallelIO
+cd ParallelIO
+git checkout -b pio-2.5.8 pio2_5_8
+export PIOSRC=`pwd`
+cd ..
+mkdir pio
+cd pio
+export CC=$MPI_CC
+export FC=$MPI_FC
+cmake -DNetCDF_C_PATH=$NETCDF -DNetCDF_Fortran_PATH=$NETCDF -DPnetCDF_PATH=$PNETCDF -DHDF5_PATH=$NETCDF -DCMAKE_INSTALL_PREFIX=$LIBBASE -DPIO_USE_MALLOC=ON -DCMAKE_VERBOSE_MAKEFILE=1 -DPIO_ENABLE_TIMING=OFF $PIOSRC
+make
+#make check
+make install
+cd ..
+rm -rf pio ParallelIO
+export PIO=$LIBBASE
+
+########################################
+# Other environment vars needed by MPAS
+########################################
+export MPAS_EXTERNAL_LIBS="-L${LIBBASE}/lib -lhdf5_hl -lhdf5 -ldl -lz"
+export MPAS_EXTERNAL_INCLUDES="-I${LIBBASE}/include"

--- a/usp-utils/install_conda_environment.sh
+++ b/usp-utils/install_conda_environment.sh
@@ -1,4 +1,9 @@
-#get directory where the sourced script is located
+#!/usr/bin/env bash
+# Run with bash (./install_conda_environment.sh or bash install_conda_environment.sh).
+# It uses bash-only features (BASH_SOURCE, [ == ]); running it with `sh`/dash
+# fails with "Bad substitution" / "unexpected operator".
+
+# get directory where this script is located
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 CYAN='\033[0;36m'

--- a/usp-utils/setup_environment.sh
+++ b/usp-utils/setup_environment.sh
@@ -29,18 +29,24 @@ fi
 export PYTHONPATH="$SCRIPT_DIR/libs/py:$PYTHONPATH"
 echo -e "${INFO} New enviroment variable set: PYTHONPATH=$PYTHONPATH"
 
-conda &> /dev/null
-status=$?
-if [ ! $status == "0" ]; then
-    echo -e "${WARNING} Couldn't find 'conda' binary, 'cgfd-usp-mpas' conda environment will not be activated. Python scripts might not work."
+if ! command -v conda &> /dev/null; then
+    echo -e "${WARNING} Couldn't find 'conda', the 'cgfd-usp-mpas' conda environment will not be activated. Python scripts might not work."
     return 1
 fi
 
-conda activate cgfd-usp-mpas &> /dev/null
-status=$?
-if [ ! $status == "0" ]; then
-    echo -e "${WARNING} Couldn't find the 'cgfd-usp-mpas' conda environment. It will not be activated and Python scripts might not work. If you wish to install the conda environment please run the script in $SCRIPT_DIR/install_conda_environment.sh"
-    return 1
+# 'conda activate' needs the 'conda' shell function; load it if only the binary
+# is on PATH (e.g. in a shell where 'conda init' hasn't run).
+if ! type conda 2> /dev/null | grep -q 'function'; then
+    __conda_sh="$(conda info --base 2> /dev/null)/etc/profile.d/conda.sh"
+    [ -f "$__conda_sh" ] && source "$__conda_sh"
 fi
 
-echo -e "${INFO} Conda enviroment 'cgfd-usp-mpas' activated"
+# Decide from the actual list of environments, not from 'activate's exit code
+# (the env may exist even if a transient activate call returns non-zero).
+if conda env list 2> /dev/null | awk '{print $1}' | grep -qx 'cgfd-usp-mpas'; then
+    conda activate cgfd-usp-mpas
+    echo -e "${INFO} Conda enviroment 'cgfd-usp-mpas' activated"
+else
+    echo -e "${WARNING} The 'cgfd-usp-mpas' conda environment was not found. It will not be activated and Python scripts might not work. To install it, run: bash $SCRIPT_DIR/install_conda_environment.sh"
+    return 1
+fi


### PR DESCRIPTION
## What

Adds a friendly, end-to-end installation/build path to `usp-utils/`, following
the NCAR MPAS-Atmosphere library workflow, so users can prepare the toolchain
and compile MPAS with clear guidance.

### New under `usp-utils/install/`
- **`download_mpas_lib_sources.sh`** — downloads & integrity-checks the 6 library
  source tarballs (MPICH, zlib, HDF5, PnetCDF, NetCDF-C/Fortran) in the exact
  versions the build script expects; PnetCDF from the official Argonne mirror.
- **`mpas_lib_install.sh`** — the unmodified NCAR script (build MPICH → … → PIO).
  Kept pristine: users try it first.
- **`INSTALL_GUIDE.md`** — full recommended flow (conda → julia → source env →
  build libs → compile MPAS → setup run dir), with a "Known build issues
  (optional fixes)" section (e.g. the gfortran ≥ 10 `FFLAGS` fix) to apply only
  if the build fails, and a troubleshooting section.
- **`.gitignore`** — keeps machine-specific `*.local.sh` copies out of the repo
  (copy-template → edit `.local.sh` pattern).

### `README.md`
Documents the install/build flow and the `.local.sh` pattern.

## Notes
- The temporary Julia `Zeros` workaround is intentionally **not** in this PR; it
  lives on the `julia/zeros-compat-workaround` branch and will be handled
  separately. The docs here only point to it.
- Validated end to end on `swell` (gfortran 13.3): libraries built, both cores
  compiled (`init_atmosphere_model`, `atmosphere_model`), and `setup_run_dir.py`
  verified.
